### PR TITLE
Feature/enable discount per order

### DIFF
--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -34,7 +34,8 @@ class InvoiceController extends Controller
         $data['menu'] = 'sales';
         $data['sub_menu'] = 'sales/direct-invoice';
 
-        $data['taxType'] = $this->sale->calculateTaxRow($invoiceNo);
+        //$data['taxType'] = $this->sale->calculateTaxRow($invoiceNo);
+        $data['taxType'] = $this->sale->calculateTaxRow($orderNo);
         $data['locData'] = DB::table('location')->get();
         
         $data['saleDataOrder'] = DB::table('sales_orders')

--- a/app/Http/Controllers/SalesController.php
+++ b/app/Http/Controllers/SalesController.php
@@ -296,6 +296,8 @@ class SalesController extends Controller
         $salesOrder['comments'] = $request->comments;
         $salesOrder['total'] = $request->total;
         $salesOrder['delivery_price'] = $request->delivery_price;
+        $salesOrderInvoice['discount_type']              = $request->discount_type;
+        $salesOrderInvoice['discount_percent']              = $request->perOrderDiscount;
         $salesOrder['payment_term'] = $request->payment_term;
         $salesOrder['updated_at'] = date('Y-m-d H:i:s');
        // d($salesOrder);

--- a/app/Http/Controllers/SalesOrderController.php
+++ b/app/Http/Controllers/SalesOrderController.php
@@ -156,6 +156,8 @@ class SalesOrderController extends Controller
         $salesOrder['from_stk_loc'] = $request->from_stk_loc;
         $salesOrder['total']        = $request->total;
         $salesOrder['delivery_price']        = $request->delivery_price;
+        $salesOrder['discount_type']        = $request->discount_type;
+        $salesOrder['discount_percent']        = $request->perOrderDiscount;
         $salesOrder['created_at']   = date('Y-m-d H:i:s');
         // d($salesOrder,1);
         $salesOrderId = \DB::table('sales_orders')->insertGetId($salesOrder);
@@ -259,6 +261,8 @@ class SalesOrderController extends Controller
         $salesOrder['comments']     = $request->comments;
         $salesOrder['total']        = $request->total;
         $salesOrder['delivery_price']        = $request->delivery_price;
+        $salesOrder['discount_type']        = $request->discount_type;
+        $salesOrder['discount_percent']        = $request->perOrderDiscount;
         $salesOrder['updated_at']   = date('Y-m-d H:i:s');
         //d($salesOrder,1);
 

--- a/app/Http/Controllers/SalesOrderController.php
+++ b/app/Http/Controllers/SalesOrderController.php
@@ -768,6 +768,8 @@ class SalesOrderController extends Controller
         $salesOrderInvoice['from_stk_loc']       = $request->from_stk_loc;
         $salesOrderInvoice['total']              = $request->total;
         $salesOrderInvoice['delivery_price']              = $request->delivery_price;
+        $salesOrderInvoice['discount_type']              = $request->discount_type;
+        $salesOrderInvoice['discount_percent']              = $request->perOrderDiscount;
         $salesOrderInvoice['payment_term']       = $request->payment_term;
         $salesOrderInvoice['created_at']         = date('Y-m-d H:i:s');
 
@@ -880,6 +882,9 @@ class SalesOrderController extends Controller
         $salesOrderInvoice['ord_date']           = $orderInfo->ord_date;
         $salesOrderInvoice['from_stk_loc']       = $orderInfo->from_stk_loc;
         $salesOrderInvoice['total']              = $total;
+        $salesOrderInvoice['delivery_price']              = $orderInfo->delivery_price;
+        $salesOrderInvoice['discount_type']              = $orderInfo->discount_type;
+        $salesOrderInvoice['discount_percent']              = $orderInfo->discount_percent;
         $salesOrderInvoice['payment_term']       = $payment_term->id;
         $salesOrderInvoice['created_at']         = date('Y-m-d H:i:s');
 

--- a/app/Http/Controllers/ShipmentController.php
+++ b/app/Http/Controllers/ShipmentController.php
@@ -344,7 +344,7 @@ class ShipmentController extends Controller
       $data['orderInfo']  = DB::table('sales_orders')
                           ->leftjoin('location','location.loc_code','=','sales_orders.from_stk_loc')
                           ->where('order_no',$order_no)
-                          ->select('sales_orders.reference','sales_orders.order_no','location.location_name')
+                          ->select('sales_orders.reference','sales_orders.order_no','location.location_name', 'sales_orders.discount_percent')
                           ->first();
       $data['invoiceList'] = DB::table('sales_orders')
                               ->where('order_reference',$data['orderInfo']->reference)
@@ -402,7 +402,7 @@ class ShipmentController extends Controller
                              ->leftjoin('debtors_master','debtors_master.debtor_no','=','sales_orders.debtor_no')
                              ->leftjoin('cust_branch','cust_branch.branch_code','=','sales_orders.branch_id')
                              ->leftjoin('countries','countries.id','=','cust_branch.shipping_country_id')
-                             ->select('debtors_master.name','debtors_master.phone','debtors_master.email','cust_branch.br_name','cust_branch.br_address','cust_branch.shipping_street','cust_branch.shipping_city','cust_branch.shipping_state','cust_branch.shipping_zip_code','countries.country','cust_branch.shipping_country_id')
+                             ->select('debtors_master.name','debtors_master.phone','debtors_master.email','cust_branch.br_name','cust_branch.br_address','cust_branch.shipping_street','cust_branch.shipping_city','cust_branch.shipping_state','cust_branch.shipping_zip_code','countries.country','cust_branch.shipping_country_id', 'sales_orders.discount_percent')
                              ->first();
       $data['shipment']   = DB::table('shipment')->where('id',$shipmentId)->select('id','status','delivery_date')->first();
       $data['order_no']   = $orderNo;
@@ -433,7 +433,7 @@ class ShipmentController extends Controller
                              ->leftjoin('debtors_master','debtors_master.debtor_no','=','sales_orders.debtor_no')
                              ->leftjoin('cust_branch','cust_branch.branch_code','=','sales_orders.branch_id')
                              ->leftjoin('countries','countries.id','=','cust_branch.shipping_country_id')
-                             ->select('debtors_master.name','debtors_master.phone','debtors_master.email','cust_branch.br_name','cust_branch.br_address','cust_branch.shipping_street','cust_branch.shipping_city','cust_branch.shipping_state','cust_branch.shipping_zip_code','countries.country','cust_branch.shipping_country_id')
+                             ->select('debtors_master.name','debtors_master.phone','debtors_master.email','cust_branch.br_name','cust_branch.br_address','cust_branch.shipping_street','cust_branch.shipping_city','cust_branch.shipping_state','cust_branch.shipping_zip_code','countries.country','cust_branch.shipping_country_id', 'sales_orders.discount_percent')
                              ->first();
       //d($data['customerInfo'],1);
       $data['shipment']   = DB::table('shipment')->where('id',$shipmentId)->select('id','status','delivery_date')->first();

--- a/app/Model/Report.php
+++ b/app/Model/Report.php
@@ -156,170 +156,532 @@ class Report extends Model
   		$whereConditions .= " AND sales_orders.from_stk_loc = '$location'";
   	}
 
-
   	if( $type=='daily' ){
   		 // Daily End Here
-$data = DB::select(DB::raw("SELECT sales_orders.ord_date,count(infos.order_no) as total_order,SUM(infos.qty) as qty,SUM(infos.purchase) as purchase,SUM(infos.sale) as sale,infos.stock_id FROM sales_orders
-				LEFT JOIN(SELECT sale_purch_detail.order_no,sale_purch_detail.stock_id, count(sale_purch_detail.order_no)as total_order,SUM(sale_purch_detail.quantity)as qty,SUM(sale_purch_detail.sale) as sale,SUM(sale_purch_detail.purchase)as purchase FROM(SELECT sales.*,(purchase.purchase_rate*sales.quantity)as purchase FROM(SELECT sods.order_no,sods.stock_id,sods.quantity,(sods.discount_price-(sods.discount_price*item_tax_types.tax_rate/100)) as sale FROM(SELECT sod.`id`, sod.`order_no`, sod.`stock_id`, sod.`unit_price`*sod.`quantity`-(sod.`unit_price`*sod.`quantity`*`discount_percent`)/100 as discount_price ,sod.`discount_percent`,sod.`quantity`,sod.`unit_price`,sod.`tax_type_id` FROM `sales_order_details` as sod )sods
-				LEFT JOIN item_tax_types
-				ON item_tax_types.id = sods.tax_type_id)sales
-
-				LEFT JOIN(SELECT pods.item_code as stock_id,(pods.price
-
-				+(pods.price*item_tax_types.tax_rate/100))/pods.qty as 
-
-				purchase_rate FROM(SELECT pod.`item_code`,SUM(pod.`unit_price`*pod.`quantity_received`) as price,SUM(pod.`quantity_received`)as qty,pod.`tax_type_id` FROM `purch_order_details` as pod
-				GROUP BY pod.item_code)pods
-
-				LEFT JOIN item_tax_types
-				ON pods.`tax_type_id` = item_tax_types.id) as purchase
-
-				ON purchase.stock_id = sales.stock_id)sale_purch_detail
-				GROUP BY sale_purch_detail.order_no)infos
-				ON infos.order_no = sales_orders.order_no
-				$whereConditions
-				GROUP BY sales_orders.ord_date 
-				ORDER BY sales_orders.ord_date DESC
+$data = DB::select(DB::raw("SELECT
+  sales_orders.ord_date,
+  COUNT(infos.order_no) AS total_order,
+  SUM(infos.qty) AS qty,
+  SUM(infos.purchase) AS purchase,
+  SUM(infos.sale) AS sale,
+  infos.stock_id
+FROM
+  sales_orders
+  LEFT JOIN
+    (SELECT
+      sale_purch_detail.order_no,
+      sale_purch_detail.stock_id,
+      COUNT(sale_purch_detail.order_no) AS total_order,
+      SUM(sale_purch_detail.quantity) AS qty,
+      SUM(sale_purch_detail.sale) AS sale,
+      SUM(sale_purch_detail.purchase) AS purchase
+    FROM
+      (SELECT
+        sales.*,
+        (
+          purchase.purchase_rate * sales.quantity
+        ) AS purchase
+      FROM
+        (SELECT
+          sods.order_no,
+          sods.stock_id,
+          sods.quantity,
+          (
+            sods.discount_price - (
+              sods.discount_price * item_tax_types.tax_rate / 100
+            ) - ((sods.discount_price*sods.order_discount)/100)
+          ) AS sale
+        FROM
+          (SELECT
+            sod.`id`,
+            sod.`order_no`,
+            sod.`stock_id`,
+            (
+              sod.`unit_price` * sod.`quantity` - (
+                sod.`unit_price` * sod.`quantity` * sod.`discount_percent`
+              ) / 100
+            ) AS discount_price,
+            sod.`discount_percent`,
+            sod.`quantity`,
+            sod.`unit_price`,
+            sod.`tax_type_id`,
+            so.`discount_percent` AS `order_discount`
+          FROM
+            `sales_order_details` AS sod
+            LEFT JOIN sales_orders AS so
+              ON so.`order_no` = sod.order_no) sods
+          LEFT JOIN item_tax_types
+            ON item_tax_types.id = sods.tax_type_id) sales
+        LEFT JOIN
+          (SELECT
+            pods.item_code AS stock_id,
+            (
+              pods.price + (
+                pods.price * item_tax_types.tax_rate / 100
+              )
+            ) / pods.qty AS purchase_rate
+          FROM
+            (SELECT
+              pod.`item_code`,
+              SUM(
+                pod.`unit_price` * pod.`quantity_received`
+              ) AS price,
+              SUM(pod.`quantity_received`) AS qty,
+              pod.`tax_type_id`
+            FROM
+              `purch_order_details` AS pod
+            GROUP BY pod.item_code) pods
+            LEFT JOIN item_tax_types
+              ON pods.`tax_type_id` = item_tax_types.id) AS purchase
+          ON purchase.stock_id = sales.stock_id) sale_purch_detail
+    GROUP BY sale_purch_detail.order_no) infos
+    ON infos.order_no = sales_orders.order_no
+$whereConditions
+GROUP BY sales_orders.ord_date
+ORDER BY sales_orders.ord_date DESC
 				"));
   		 // Daily End Here
   	}else if( $type=='monthly' ){
 
-   			$data = DB::select(DB::raw("SELECT sales_orders.ord_date,count(infos.order_no) as total_order,SUM(infos.qty) as qty,SUM(infos.purchase) as purchase,SUM(infos.sale) as sale,infos.stock_id FROM sales_orders
-				LEFT JOIN(SELECT sale_purch_detail.order_no,sale_purch_detail.stock_id, count(sale_purch_detail.order_no)as total_order,SUM(sale_purch_detail.quantity)as qty,SUM(sale_purch_detail.sale) as sale,SUM(sale_purch_detail.purchase)as purchase FROM(SELECT sales.*,(purchase.purchase_rate*sales.quantity)as purchase FROM(SELECT sods.order_no,sods.stock_id,sods.quantity,(sods.discount_price-(sods.discount_price*item_tax_types.tax_rate/100)) as sale FROM(SELECT sod.`id`, sod.`order_no`, sod.`stock_id`, sod.`unit_price`*sod.`quantity`-(sod.`unit_price`*sod.`quantity`*`discount_percent`)/100 as discount_price ,sod.`discount_percent`,sod.`quantity`,sod.`unit_price`,sod.`tax_type_id` FROM `sales_order_details` as sod)sods
-				LEFT JOIN item_tax_types
-				ON item_tax_types.id = sods.tax_type_id)sales
-
-				LEFT JOIN(SELECT pods.item_code as stock_id,(pods.price
-
-				+(pods.price*item_tax_types.tax_rate/100))/pods.qty as 
-
-				purchase_rate FROM(SELECT pod.`item_code`,SUM(pod.`unit_price`*pod.`quantity_received`) as price,SUM(pod.`quantity_received`)as qty,pod.`tax_type_id` FROM `purch_order_details` as pod
-				GROUP BY pod.item_code)pods
-
-				LEFT JOIN item_tax_types
-				ON pods.`tax_type_id` = item_tax_types.id) as purchase
-
-				ON purchase.stock_id = sales.stock_id)sale_purch_detail
-				GROUP BY sale_purch_detail.order_no)infos
-				ON infos.order_no = sales_orders.order_no
-
-				$whereConditions
-
-                AND YEAR(sales_orders.ord_date) = YEAR(NOW())
-                GROUP BY MONTH(sales_orders.ord_date)
-				ORDER BY sales_orders.ord_date DESC
+   			$data = DB::select(DB::raw("SELECT
+  sales_orders.ord_date,
+  COUNT(infos.order_no) AS total_order,
+  SUM(infos.qty) AS qty,
+  SUM(infos.purchase) AS purchase,
+  SUM(infos.sale) AS sale,
+  infos.stock_id
+FROM
+  sales_orders
+  LEFT JOIN
+    (SELECT
+      sale_purch_detail.order_no,
+      sale_purch_detail.stock_id,
+      COUNT(sale_purch_detail.order_no) AS total_order,
+      SUM(sale_purch_detail.quantity) AS qty,
+      SUM(sale_purch_detail.sale) AS sale,
+      SUM(sale_purch_detail.purchase) AS purchase
+    FROM
+      (SELECT
+        sales.*,
+        (
+          purchase.purchase_rate * sales.quantity
+        ) AS purchase
+      FROM
+        (SELECT
+          sods.order_no,
+          sods.stock_id,
+          sods.quantity,
+          (
+            sods.discount_price - (
+              sods.discount_price * item_tax_types.tax_rate / 100
+            ) - (
+              (
+                sods.discount_price * sods.order_discount
+              ) / 100
+            )
+          ) AS sale
+        FROM
+          (SELECT
+            sod.`id`,
+            sod.`order_no`,
+            sod.`stock_id`,
+            sod.`unit_price` * sod.`quantity` - (
+              sod.`unit_price` * sod.`quantity` * sod.`discount_percent`
+            ) / 100 AS discount_price,
+            sod.`discount_percent`,
+            sod.`quantity`,
+            sod.`unit_price`,
+            sod.`tax_type_id`,
+            so.`discount_percent` AS `order_discount`
+          FROM
+            `sales_order_details` AS sod
+            LEFT JOIN sales_orders AS so
+              ON so.`order_no` = sod.order_no) sods
+          LEFT JOIN item_tax_types
+            ON item_tax_types.id = sods.tax_type_id) sales
+        LEFT JOIN
+          (SELECT
+            pods.item_code AS stock_id,
+            (
+              pods.price + (
+                pods.price * item_tax_types.tax_rate / 100
+              )
+            ) / pods.qty AS purchase_rate
+          FROM
+            (SELECT
+              pod.`item_code`,
+              SUM(
+                pod.`unit_price` * pod.`quantity_received`
+              ) AS price,
+              SUM(pod.`quantity_received`) AS qty,
+              pod.`tax_type_id`
+            FROM
+              `purch_order_details` AS pod
+            GROUP BY pod.item_code) pods
+            LEFT JOIN item_tax_types
+              ON pods.`tax_type_id` = item_tax_types.id) AS purchase
+          ON purchase.stock_id = sales.stock_id) sale_purch_detail
+    GROUP BY sale_purch_detail.order_no) infos
+    ON infos.order_no = sales_orders.order_no
+$whereConditions
+  AND YEAR(sales_orders.ord_date) = YEAR(NOW())
+GROUP BY MONTH(sales_orders.ord_date)
+ORDER BY sales_orders.ord_date DESC
 				"));
-
   	}else if( $type=='yearly' ){
   		//d($type,1);
   		if( $year=='all' ){
-   			$data = DB::select(DB::raw("SELECT sales_orders.ord_date,count(infos.order_no) as total_order,SUM(infos.qty) as qty,SUM(infos.purchase) as purchase,SUM(infos.sale) as sale,infos.stock_id FROM sales_orders
-				LEFT JOIN(SELECT sale_purch_detail.order_no,sale_purch_detail.stock_id, count(sale_purch_detail.order_no)as total_order,SUM(sale_purch_detail.quantity)as qty,SUM(sale_purch_detail.sale) as sale,SUM(sale_purch_detail.purchase)as purchase FROM(SELECT sales.*,(purchase.purchase_rate*sales.quantity)as purchase FROM(SELECT sods.order_no,sods.stock_id,sods.quantity,(sods.discount_price-(sods.discount_price*item_tax_types.tax_rate/100)) as sale FROM(SELECT sod.`id`, sod.`order_no`, sod.`stock_id`, sod.`unit_price`*sod.`quantity`-(sod.`unit_price`*sod.`quantity`*`discount_percent`)/100 as discount_price ,sod.`discount_percent`,sod.`quantity`,sod.`unit_price`,sod.`tax_type_id` FROM `sales_order_details` as sod)sods
-				LEFT JOIN item_tax_types
-				ON item_tax_types.id = sods.tax_type_id)sales
-
-				LEFT JOIN(SELECT pods.item_code as stock_id,(pods.price
-
-				+(pods.price*item_tax_types.tax_rate/100))/pods.qty as 
-
-				purchase_rate FROM(SELECT pod.`item_code`,SUM(pod.`unit_price`*pod.`quantity_received`) as price,SUM(pod.`quantity_received`)as qty,pod.`tax_type_id` FROM `purch_order_details` as pod
-				GROUP BY pod.item_code)pods
-
-				LEFT JOIN item_tax_types
-				ON pods.`tax_type_id` = item_tax_types.id) as purchase
-
-				ON purchase.stock_id = sales.stock_id)sale_purch_detail
-				GROUP BY sale_purch_detail.order_no)infos
-				ON infos.order_no = sales_orders.order_no
-				$whereConditions
-				GROUP BY YEAR(sales_orders.ord_date)
-				ORDER BY sales_orders.ord_date DESC
-				"));
+   			$data = DB::select(DB::raw("SELECT
+  sales_orders.ord_date,
+  COUNT(infos.order_no) AS total_order,
+  SUM(infos.qty) AS qty,
+  SUM(infos.purchase) AS purchase,
+  SUM(infos.sale) AS sale,
+  infos.stock_id
+FROM
+  sales_orders
+  LEFT JOIN
+    (SELECT
+      sale_purch_detail.order_no,
+      sale_purch_detail.stock_id,
+      COUNT(sale_purch_detail.order_no) AS total_order,
+      SUM(sale_purch_detail.quantity) AS qty,
+      SUM(sale_purch_detail.sale) AS sale,
+      SUM(sale_purch_detail.purchase) AS purchase
+    FROM
+      (SELECT
+        sales.*,
+        (
+          purchase.purchase_rate * sales.quantity
+        ) AS purchase
+      FROM
+        (SELECT
+          sods.order_no,
+          sods.stock_id,
+          sods.quantity,
+          (
+            sods.discount_price - (
+              sods.discount_price * item_tax_types.tax_rate / 100
+            ) - (
+              (
+                sods.discount_price * sods.order_discount
+              ) / 100
+            )
+          ) AS sale
+        FROM
+          (SELECT
+            sod.`id`,
+            sod.`order_no`,
+            sod.`stock_id`,
+            sod.`unit_price` * sod.`quantity` - (
+              sod.`unit_price` * sod.`quantity` * sod.`discount_percent`
+            ) / 100 AS discount_price,
+            sod.`discount_percent`,
+            sod.`quantity`,
+            sod.`unit_price`,
+            sod.`tax_type_id`,
+            so.`discount_percent` AS `order_discount`
+          FROM
+            `sales_order_details` AS sod
+            LEFT JOIN sales_orders AS so
+              ON so.`order_no` = sod.order_no) sods
+          LEFT JOIN item_tax_types
+            ON item_tax_types.id = sods.tax_type_id) sales
+        LEFT JOIN
+          (SELECT
+            pods.item_code AS stock_id,
+            (
+              pods.price + (
+                pods.price * item_tax_types.tax_rate / 100
+              )
+            ) / pods.qty AS purchase_rate
+          FROM
+            (SELECT
+              pod.`item_code`,
+              SUM(
+                pod.`unit_price` * pod.`quantity_received`
+              ) AS price,
+              SUM(pod.`quantity_received`) AS qty,
+              pod.`tax_type_id`
+            FROM
+              `purch_order_details` AS pod
+            GROUP BY pod.item_code) pods
+            LEFT JOIN item_tax_types
+              ON pods.`tax_type_id` = item_tax_types.id) AS purchase
+          ON purchase.stock_id = sales.stock_id) sale_purch_detail
+    GROUP BY sale_purch_detail.order_no) infos
+    ON infos.order_no = sales_orders.order_no
+$whereConditions
+GROUP BY YEAR(sales_orders.ord_date)
+ORDER BY sales_orders.ord_date DESC "));
   		}elseif ($year !='all') {
   			if( $month=='all' ){
-   			$data = DB::select(DB::raw("SELECT sales_orders.ord_date,count(infos.order_no) as total_order,SUM(infos.qty) as qty,SUM(infos.purchase) as purchase,SUM(infos.sale) as sale,infos.stock_id FROM sales_orders
-				LEFT JOIN(SELECT sale_purch_detail.order_no,sale_purch_detail.stock_id, count(sale_purch_detail.order_no)as total_order,SUM(sale_purch_detail.quantity)as qty,SUM(sale_purch_detail.sale) as sale,SUM(sale_purch_detail.purchase)as purchase FROM(SELECT sales.*,(purchase.purchase_rate*sales.quantity)as purchase FROM(SELECT sods.order_no,sods.stock_id,sods.quantity,(sods.discount_price-(sods.discount_price*item_tax_types.tax_rate/100)) as sale FROM(SELECT sod.`id`, sod.`order_no`, sod.`stock_id`, sod.`unit_price`*sod.`quantity`-(sod.`unit_price`*sod.`quantity`*`discount_percent`)/100 as discount_price ,sod.`discount_percent`,sod.`quantity`,sod.`unit_price`,sod.`tax_type_id` FROM `sales_order_details` as sod)sods
-				LEFT JOIN item_tax_types
-				ON item_tax_types.id = sods.tax_type_id)sales
-
-				LEFT JOIN(SELECT pods.item_code as stock_id,(pods.price
-
-				+(pods.price*item_tax_types.tax_rate/100))/pods.qty as 
-
-				purchase_rate FROM(SELECT pod.`item_code`,SUM(pod.`unit_price`*pod.`quantity_received`) as price,SUM(pod.`quantity_received`)as qty,pod.`tax_type_id` FROM `purch_order_details` as pod
-				GROUP BY pod.item_code)pods
-
-				LEFT JOIN item_tax_types
-				ON pods.`tax_type_id` = item_tax_types.id) as purchase
-
-				ON purchase.stock_id = sales.stock_id)sale_purch_detail
-				GROUP BY sale_purch_detail.order_no)infos
-				ON infos.order_no = sales_orders.order_no
-				$whereConditions
-                AND YEAR(sales_orders.ord_date) = '$year'
-                GROUP BY MONTH(sales_orders.ord_date)
-				ORDER BY sales_orders.ord_date DESC
-				")); 
+   			$data = DB::select(DB::raw("SELECT
+  sales_orders.ord_date,
+  COUNT(infos.order_no) AS total_order,
+  SUM(infos.qty) AS qty,
+  SUM(infos.purchase) AS purchase,
+  SUM(infos.sale) AS sale,
+  infos.stock_id
+FROM
+  sales_orders
+  LEFT JOIN
+    (SELECT
+      sale_purch_detail.order_no,
+      sale_purch_detail.stock_id,
+      COUNT(sale_purch_detail.order_no) AS total_order,
+      SUM(sale_purch_detail.quantity) AS qty,
+      SUM(sale_purch_detail.sale) AS sale,
+      SUM(sale_purch_detail.purchase) AS purchase
+    FROM
+      (SELECT
+        sales.*,
+        (
+          purchase.purchase_rate * sales.quantity
+        ) AS purchase
+      FROM
+        (SELECT
+          sods.order_no,
+          sods.stock_id,
+          sods.quantity,
+          (
+            sods.discount_price - (
+              sods.discount_price * item_tax_types.tax_rate / 100
+            ) - (
+              (
+                sods.discount_price * sods.order_discount
+              ) / 100
+            )
+          ) AS sale
+        FROM
+          (SELECT
+            sod.`id`,
+            sod.`order_no`,
+            sod.`stock_id`,
+            sod.`unit_price` * sod.`quantity` - (
+              sod.`unit_price` * sod.`quantity` * sod.`discount_percent`
+            ) / 100 AS discount_price,
+            sod.`discount_percent`,
+            sod.`quantity`,
+            sod.`unit_price`,
+            sod.`tax_type_id`,
+            so.`discount_percent` AS `order_discount`
+          FROM
+            `sales_order_details` AS sod
+            LEFT JOIN sales_orders AS so
+              ON so.`order_no` = sod.order_no) sods
+          LEFT JOIN item_tax_types
+            ON item_tax_types.id = sods.tax_type_id) sales
+        LEFT JOIN
+          (SELECT
+            pods.item_code AS stock_id,
+            (
+              pods.price + (
+                pods.price * item_tax_types.tax_rate / 100
+              )
+            ) / pods.qty AS purchase_rate
+          FROM
+            (SELECT
+              pod.`item_code`,
+              SUM(
+                pod.`unit_price` * pod.`quantity_received`
+              ) AS price,
+              SUM(pod.`quantity_received`) AS qty,
+              pod.`tax_type_id`
+            FROM
+              `purch_order_details` AS pod
+            GROUP BY pod.item_code) pods
+            LEFT JOIN item_tax_types
+              ON pods.`tax_type_id` = item_tax_types.id) AS purchase
+          ON purchase.stock_id = sales.stock_id) sale_purch_detail
+    GROUP BY sale_purch_detail.order_no) infos
+    ON infos.order_no = sales_orders.order_no
+$whereConditions
+  AND YEAR(sales_orders.ord_date) = '$year'
+GROUP BY MONTH(sales_orders.ord_date)
+ORDER BY sales_orders.ord_date DESC "));
   		}else if( $month !='all'){
-
-   			$data = DB::select(DB::raw("SELECT sales_orders.ord_date,count(infos.order_no) as total_order,SUM(infos.qty) as qty,SUM(infos.purchase) as purchase,SUM(infos.sale) as sale,infos.stock_id FROM sales_orders
-				LEFT JOIN(SELECT sale_purch_detail.order_no,sale_purch_detail.stock_id, count(sale_purch_detail.order_no)as total_order,SUM(sale_purch_detail.quantity)as qty,SUM(sale_purch_detail.sale) as sale,SUM(sale_purch_detail.purchase)as purchase FROM(SELECT sales.*,(purchase.purchase_rate*sales.quantity)as purchase FROM(SELECT sods.order_no,sods.stock_id,sods.quantity,(sods.discount_price-(sods.discount_price*item_tax_types.tax_rate/100)) as sale FROM(SELECT sod.`id`, sod.`order_no`, sod.`stock_id`, sod.`unit_price`*sod.`quantity`-(sod.`unit_price`*sod.`quantity`*`discount_percent`)/100 as discount_price ,sod.`discount_percent`,sod.`quantity`,sod.`unit_price`,sod.`tax_type_id` FROM `sales_order_details` as sod)sods
-				LEFT JOIN item_tax_types
-				ON item_tax_types.id = sods.tax_type_id)sales
-
-				LEFT JOIN(SELECT pods.item_code as stock_id,(pods.price
-
-				+(pods.price*item_tax_types.tax_rate/100))/pods.qty as 
-
-				purchase_rate FROM(SELECT pod.`item_code`,SUM(pod.`unit_price`*pod.`quantity_received`) as price,SUM(pod.`quantity_received`)as qty,pod.`tax_type_id` FROM `purch_order_details` as pod
-				GROUP BY pod.item_code)pods
-
-				LEFT JOIN item_tax_types
-				ON pods.`tax_type_id` = item_tax_types.id) as purchase
-
-				ON purchase.stock_id = sales.stock_id)sale_purch_detail
-				GROUP BY sale_purch_detail.order_no)infos
-				ON infos.order_no = sales_orders.order_no
-				$whereConditions
-                AND YEAR(sales_orders.ord_date) = '$year'
-                AND MONTH(sales_orders.ord_date) = '$month'
-                GROUP BY sales_orders.ord_date
-				ORDER BY sales_orders.ord_date DESC
-				"));
+   			$data = DB::select(DB::raw("SELECT
+  sales_orders.ord_date,
+  COUNT(infos.order_no) AS total_order,
+  SUM(infos.qty) AS qty,
+  SUM(infos.purchase) AS purchase,
+  SUM(infos.sale) AS sale,
+  infos.stock_id
+FROM
+  sales_orders
+  LEFT JOIN
+    (SELECT
+      sale_purch_detail.order_no,
+      sale_purch_detail.stock_id,
+      COUNT(sale_purch_detail.order_no) AS total_order,
+      SUM(sale_purch_detail.quantity) AS qty,
+      SUM(sale_purch_detail.sale) AS sale,
+      SUM(sale_purch_detail.purchase) AS purchase
+    FROM
+      (SELECT
+        sales.*,
+        (
+          purchase.purchase_rate * sales.quantity
+        ) AS purchase
+      FROM
+        (SELECT
+          sods.order_no,
+          sods.stock_id,
+          sods.quantity,
+          (
+            sods.discount_price - (
+              sods.discount_price * item_tax_types.tax_rate / 100
+            ) - (
+              (
+                sods.discount_price * sods.order_discount
+              ) / 100
+            )
+          ) AS sale
+        FROM
+          (SELECT
+            sod.`id`,
+            sod.`order_no`,
+            sod.`stock_id`,
+            sod.`unit_price` * sod.`quantity` - (
+              sod.`unit_price` * sod.`quantity` * sod.`discount_percent`
+            ) / 100 AS discount_price,
+            sod.`discount_percent`,
+            sod.`quantity`,
+            sod.`unit_price`,
+            sod.`tax_type_id`,
+            so.`discount_percent` AS `order_discount`
+          FROM
+            `sales_order_details` AS sod
+            LEFT JOIN sales_orders AS so
+              ON so.`order_no` = sod.order_no) sods
+          LEFT JOIN item_tax_types
+            ON item_tax_types.id = sods.tax_type_id) sales
+        LEFT JOIN
+          (SELECT
+            pods.item_code AS stock_id,
+            (
+              pods.price + (
+                pods.price * item_tax_types.tax_rate / 100
+              )
+            ) / pods.qty AS purchase_rate
+          FROM
+            (SELECT
+              pod.`item_code`,
+              SUM(
+                pod.`unit_price` * pod.`quantity_received`
+              ) AS price,
+              SUM(pod.`quantity_received`) AS qty,
+              pod.`tax_type_id`
+            FROM
+              `purch_order_details` AS pod
+            GROUP BY pod.item_code) pods
+            LEFT JOIN item_tax_types
+              ON pods.`tax_type_id` = item_tax_types.id) AS purchase
+          ON purchase.stock_id = sales.stock_id) sale_purch_detail
+    GROUP BY sale_purch_detail.order_no) infos
+    ON infos.order_no = sales_orders.order_no
+$whereConditions
+  AND YEAR(sales_orders.ord_date) = '$year'
+  AND MONTH(sales_orders.ord_date) = '$month'
+GROUP BY sales_orders.ord_date
+ORDER BY sales_orders.ord_date DESC "));
   			}
   		}
 
   	}elseif($type=='custom'){
-   			$data = DB::select(DB::raw("SELECT sales_orders.ord_date,count(infos.order_no) as total_order,SUM(infos.qty) as qty,SUM(infos.purchase) as purchase,SUM(infos.sale) as sale,infos.stock_id FROM sales_orders
-				LEFT JOIN(SELECT sale_purch_detail.order_no,sale_purch_detail.stock_id, count(sale_purch_detail.order_no)as total_order,SUM(sale_purch_detail.quantity)as qty,SUM(sale_purch_detail.sale) as sale,SUM(sale_purch_detail.purchase)as purchase FROM(SELECT sales.*,(purchase.purchase_rate*sales.quantity)as purchase FROM(SELECT sods.order_no,sods.stock_id,sods.quantity,(sods.discount_price-(sods.discount_price*item_tax_types.tax_rate/100)) as sale FROM(SELECT sod.`id`, sod.`order_no`, sod.`stock_id`, sod.`unit_price`*sod.`quantity`-(sod.`unit_price`*sod.`quantity`*`discount_percent`)/100 as discount_price ,sod.`discount_percent`,sod.`quantity`,sod.`unit_price`,sod.`tax_type_id` FROM `sales_order_details` as sod)sods
-				LEFT JOIN item_tax_types
-				ON item_tax_types.id = sods.tax_type_id)sales
-
-				LEFT JOIN(SELECT pods.item_code as stock_id,(pods.price
-
-				+(pods.price*item_tax_types.tax_rate/100))/pods.qty as 
-
-				purchase_rate FROM(SELECT pod.`item_code`,SUM(pod.`unit_price`*pod.`quantity_received`) as price,SUM(pod.`quantity_received`)as qty,pod.`tax_type_id` FROM `purch_order_details` as pod
-				GROUP BY pod.item_code)pods
-
-				LEFT JOIN item_tax_types
-				ON pods.`tax_type_id` = item_tax_types.id) as purchase
-
-				ON purchase.stock_id = sales.stock_id)sale_purch_detail
-				GROUP BY sale_purch_detail.order_no)infos
-				ON infos.order_no = sales_orders.order_no
-				$whereConditions
-                AND sales_orders.ord_date BETWEEN '$from' AND '$to'
-                GROUP BY sales_orders.ord_date
-				ORDER BY sales_orders.ord_date DESC
-				"));    	
+   			$data = DB::select(DB::raw("SELECT
+  sales_orders.ord_date,
+  COUNT(infos.order_no) AS total_order,
+  SUM(infos.qty) AS qty,
+  SUM(infos.purchase) AS purchase,
+  SUM(infos.sale) AS sale,
+  infos.stock_id
+FROM
+  sales_orders
+  LEFT JOIN
+    (SELECT
+      sale_purch_detail.order_no,
+      sale_purch_detail.stock_id,
+      COUNT(sale_purch_detail.order_no) AS total_order,
+      SUM(sale_purch_detail.quantity) AS qty,
+      SUM(sale_purch_detail.sale) AS sale,
+      SUM(sale_purch_detail.purchase) AS purchase
+    FROM
+      (SELECT
+        sales.*,
+        (
+          purchase.purchase_rate * sales.quantity
+        ) AS purchase
+      FROM
+        (SELECT
+          sods.order_no,
+          sods.stock_id,
+          sods.quantity,
+          (
+            sods.discount_price - (
+              sods.discount_price * item_tax_types.tax_rate / 100
+            ) - (
+              (
+                sods.discount_price * sods.order_discount
+              ) / 100
+            )
+          ) AS sale
+        FROM
+          (SELECT
+            sod.`id`,
+            sod.`order_no`,
+            sod.`stock_id`,
+            sod.`unit_price` * sod.`quantity` - (
+              sod.`unit_price` * sod.`quantity` * sod.`discount_percent`
+            ) / 100 AS discount_price,
+            sod.`discount_percent`,
+            sod.`quantity`,
+            sod.`unit_price`,
+            sod.`tax_type_id`,
+            so.`discount_percent` AS `order_discount`
+          FROM
+            `sales_order_details` AS sod
+            LEFT JOIN sales_orders AS so
+              ON so.`order_no` = sod.order_no) sods
+          LEFT JOIN item_tax_types
+            ON item_tax_types.id = sods.tax_type_id) sales
+        LEFT JOIN
+          (SELECT
+            pods.item_code AS stock_id,
+            (
+              pods.price + (
+                pods.price * item_tax_types.tax_rate / 100
+              )
+            ) / pods.qty AS purchase_rate
+          FROM
+            (SELECT
+              pod.`item_code`,
+              SUM(
+                pod.`unit_price` * pod.`quantity_received`
+              ) AS price,
+              SUM(pod.`quantity_received`) AS qty,
+              pod.`tax_type_id`
+            FROM
+              `purch_order_details` AS pod
+            GROUP BY pod.item_code) pods
+            LEFT JOIN item_tax_types
+              ON pods.`tax_type_id` = item_tax_types.id) AS purchase
+          ON purchase.stock_id = sales.stock_id) sale_purch_detail
+    GROUP BY sale_purch_detail.order_no) infos
+    ON infos.order_no = sales_orders.order_no
+$whereConditions
+  AND sales_orders.ord_date BETWEEN '$from'
+  AND '$to'
+GROUP BY sales_orders.ord_date
+ORDER BY sales_orders.ord_date DESC "));
 	}
     	return $data;
 
     }
 
     public function getSalesReportByDate($date){
-		$data = DB::select(DB::raw("SELECT info_tbl.*,dm.name FROM(SELECT final_tbl.ord_date,final_tbl.order_reference,final_tbl.reference,final_tbl.debtor_no,final_tbl.order_reference_id,final_tbl.order_no AS primary_order_no, SUM(final_tbl.quantity) as qty,SUM(final_tbl.sales_price) as sales_price_total,SUM(final_tbl.tax_amount)as tax,SUM(final_tbl.purchase_price) as purch_price_amount FROM(SELECT sod.*,so.ord_date,so.order_reference,so.reference,so.debtor_no,so.order_reference_id,so.order_no AS primary_order_no,(sod.quantity*sod.unit_price-sod.quantity*sod.unit_price*sod.discount_percent/100) as sales_price,(sod.quantity*sod.unit_price*tax.tax_rate/100) as tax_amount,purchase_table.rate as purchase_unit_price,(sod.quantity*purchase_table.rate) as purchase_price FROM(SELECT sales_order_details.order_no,sales_order_details.stock_id,sales_order_details.`quantity`,sales_order_details.`unit_price`,sales_order_details.`discount_percent`,sales_order_details.`tax_type_id` as tax_id FROM `sales_order_details`)sod
+		$data = DB::select(DB::raw("SELECT info_tbl.*,dm.name FROM(SELECT final_tbl.ord_date,final_tbl.order_reference,final_tbl.reference,final_tbl.debtor_no,final_tbl.order_reference_id,final_tbl.order_no AS primary_order_no,final_tbl.order_discount_percent AS order_discount_percent, SUM(final_tbl.quantity) as qty,SUM(final_tbl.sales_price) as sales_price_total,SUM(final_tbl.tax_amount)as tax,SUM(final_tbl.purchase_price) as purch_price_amount FROM(SELECT sod.*,so.ord_date,so.order_reference,so.reference,so.debtor_no,so.order_reference_id,so.order_no AS primary_order_no, so.discount_percent AS order_discount_percent,(sod.quantity*sod.unit_price-sod.quantity*sod.unit_price*sod.discount_percent/100) as sales_price,((sod.quantity*sod.unit_price-(sod.quantity*sod.unit_price*sod.discount_percent/100))*tax.tax_rate/100) as tax_amount,purchase_table.rate as purchase_unit_price,(sod.quantity*purchase_table.rate) as purchase_price FROM(SELECT sales_order_details.order_no,sales_order_details.stock_id,sales_order_details.`quantity`,sales_order_details.`unit_price`,sales_order_details.`discount_percent`,sales_order_details.`tax_type_id` as tax_id FROM `sales_order_details`)sod
 				LEFT JOIN item_tax_types as tax
 				ON tax.id = sod.tax_id
 
@@ -340,7 +702,7 @@ $data = DB::select(DB::raw("SELECT sales_orders.ord_date,count(infos.order_no) a
 
     public function getSalesHistoryReport($from,$to,$user){
     	if($from == NULL || $to == NULL || $user == NULL){
-    	        $data = DB::select(DB::raw("SELECT info_tbl.*,dm.name FROM(SELECT final_tbl.ord_date,final_tbl.order_reference,final_tbl.reference,final_tbl.debtor_no,final_tbl.order_no,final_tbl.order_reference_id,final_tbl.order_no AS primary_order_no, SUM(final_tbl.quantity) as qty,SUM(final_tbl.sales_price) as sales_price_total,SUM(final_tbl.tax_amount)as tax,SUM(final_tbl.purchase_price) as purch_price_amount FROM(SELECT sod.*,so.ord_date,so.order_reference,so.reference,so.debtor_no,so.order_reference_id,so.order_no AS primary_order_no,(sod.quantity*sod.unit_price-sod.quantity*sod.unit_price*sod.discount_percent/100) as sales_price,(sod.quantity*sod.unit_price*tax.tax_rate/100) as tax_amount,purchase_table.rate as purchase_unit_price,(sod.quantity*purchase_table.rate) as purchase_price FROM(SELECT sales_order_details.order_no,sales_order_details.stock_id,sales_order_details.`quantity`,sales_order_details.`unit_price`,sales_order_details.`discount_percent`,sales_order_details.`tax_type_id` as tax_id FROM `sales_order_details`)sod
+    	        $data = DB::select(DB::raw("SELECT info_tbl.*,dm.name FROM(SELECT final_tbl.ord_date,final_tbl.order_reference,final_tbl.reference,final_tbl.debtor_no,final_tbl.order_no,final_tbl.order_reference_id,final_tbl.order_no AS primary_order_no,final_tbl.order_discount_percent AS order_discount_percent, SUM(final_tbl.quantity) as qty,SUM(final_tbl.sales_price) as sales_price_total,SUM(final_tbl.tax_amount)as tax,SUM(final_tbl.purchase_price) as purch_price_amount FROM(SELECT sod.*,so.ord_date,so.order_reference,so.reference,so.debtor_no,so.order_reference_id,so.order_no AS primary_order_no,so.discount_percent AS order_discount_percent,(sod.quantity*sod.unit_price-sod.quantity*sod.unit_price*sod.discount_percent/100) as sales_price,((sod.quantity*sod.unit_price-(sod.quantity*sod.unit_price*sod.discount_percent/100))*tax.tax_rate/100) as tax_amount,purchase_table.rate as purchase_unit_price,(sod.quantity*purchase_table.rate) as purchase_price FROM(SELECT sales_order_details.order_no,sales_order_details.stock_id,sales_order_details.`quantity`,sales_order_details.`unit_price`,sales_order_details.`discount_percent`,sales_order_details.`tax_type_id` as tax_id FROM `sales_order_details`)sod
 				LEFT JOIN item_tax_types as tax
 				ON tax.id = sod.tax_id
 
@@ -358,7 +720,7 @@ $data = DB::select(DB::raw("SELECT sales_orders.ord_date,count(infos.order_no) a
 
 				"));
 			}else if($user == 'all' && $from != NULL && $to != NULL){
-    	        $data = DB::select(DB::raw("SELECT info_tbl.*,dm.name FROM(SELECT final_tbl.ord_date,final_tbl.order_reference,final_tbl.reference,final_tbl.debtor_no,final_tbl.order_no,final_tbl.order_reference_id,final_tbl.order_no AS primary_order_no, SUM(final_tbl.quantity) as qty,SUM(final_tbl.sales_price) as sales_price_total,SUM(final_tbl.tax_amount)as tax,SUM(final_tbl.purchase_price) as purch_price_amount FROM(SELECT sod.*,so.ord_date,so.order_reference,so.reference,so.debtor_no,so.order_reference_id,so.order_no AS primary_order_no,(sod.quantity*sod.unit_price-sod.quantity*sod.unit_price*sod.discount_percent/100) as sales_price,(sod.quantity*sod.unit_price*tax.tax_rate/100) as tax_amount,purchase_table.rate as purchase_unit_price,(sod.quantity*purchase_table.rate) as purchase_price FROM(SELECT sales_order_details.order_no,sales_order_details.stock_id,sales_order_details.`quantity`,sales_order_details.`unit_price`,sales_order_details.`discount_percent`,sales_order_details.`tax_type_id` as tax_id FROM `sales_order_details`)sod
+    	        $data = DB::select(DB::raw("SELECT info_tbl.*,dm.name FROM(SELECT final_tbl.ord_date,final_tbl.order_reference,final_tbl.reference,final_tbl.debtor_no,final_tbl.order_no,final_tbl.order_reference_id,final_tbl.order_no AS primary_order_no,final_tbl.order_discount_percent AS order_discount_percent, SUM(final_tbl.quantity) as qty,SUM(final_tbl.sales_price) as sales_price_total,SUM(final_tbl.tax_amount)as tax,SUM(final_tbl.purchase_price) as purch_price_amount FROM(SELECT sod.*,so.ord_date,so.order_reference,so.reference,so.debtor_no,so.order_reference_id,so.order_no AS primary_order_no,so.discount_percent AS order_discount_percent,(sod.quantity*sod.unit_price-sod.quantity*sod.unit_price*sod.discount_percent/100) as sales_price,((sod.quantity*sod.unit_price-(sod.quantity*sod.unit_price*sod.discount_percent/100))*tax.tax_rate/100) as tax_amount,purchase_table.rate as purchase_unit_price,(sod.quantity*purchase_table.rate) as purchase_price FROM(SELECT sales_order_details.order_no,sales_order_details.stock_id,sales_order_details.`quantity`,sales_order_details.`unit_price`,sales_order_details.`discount_percent`,sales_order_details.`tax_type_id` as tax_id FROM `sales_order_details`)sod
 				LEFT JOIN item_tax_types as tax
 				ON tax.id = sod.tax_id
 
@@ -377,7 +739,7 @@ $data = DB::select(DB::raw("SELECT sales_orders.ord_date,count(infos.order_no) a
 
 				"));
 			}else if($user != 'all' && $from != NULL && $to != NULL){
-    	        $data = DB::select(DB::raw("SELECT info_tbl.*,dm.name FROM(SELECT final_tbl.ord_date,final_tbl.order_reference,final_tbl.reference,final_tbl.debtor_no,final_tbl.order_no,final_tbl.order_reference_id,final_tbl.order_no AS primary_order_no, SUM(final_tbl.quantity) as qty,SUM(final_tbl.sales_price) as sales_price_total,SUM(final_tbl.tax_amount)as tax,SUM(final_tbl.purchase_price) as purch_price_amount FROM(SELECT sod.*,so.ord_date,so.order_reference,so.reference,so.debtor_no,so.order_reference_id,so.order_no AS primary_order_no,(sod.quantity*sod.unit_price-sod.quantity*sod.unit_price*sod.discount_percent/100) as sales_price,(sod.quantity*sod.unit_price*tax.tax_rate/100) as tax_amount,purchase_table.rate as purchase_unit_price,(sod.quantity*purchase_table.rate) as purchase_price FROM(SELECT sales_order_details.order_no,sales_order_details.stock_id,sales_order_details.`quantity`,sales_order_details.`unit_price`,sales_order_details.`discount_percent`,sales_order_details.`tax_type_id` as tax_id FROM `sales_order_details` WHERE `trans_type`=202)sod
+    	        $data = DB::select(DB::raw("SELECT info_tbl.*,dm.name FROM(SELECT final_tbl.ord_date,final_tbl.order_reference,final_tbl.reference,final_tbl.debtor_no,final_tbl.order_no,final_tbl.order_reference_id,final_tbl.order_no AS primary_order_no,final_tbl.order_discount_percent AS order_discount_percent, SUM(final_tbl.quantity) as qty,SUM(final_tbl.sales_price) as sales_price_total,SUM(final_tbl.tax_amount)as tax,SUM(final_tbl.purchase_price) as purch_price_amount FROM(SELECT sod.*,so.ord_date,so.order_reference,so.reference,so.debtor_no,so.order_reference_id,so.order_no AS primary_order_no,so.discount_percent AS order_discount_percent,(sod.quantity*sod.unit_price-sod.quantity*sod.unit_price*sod.discount_percent/100) as sales_price,((sod.quantity*sod.unit_price-(sod.quantity*sod.unit_price*sod.discount_percent/100))*tax.tax_rate/100) as tax_amount,purchase_table.rate as purchase_unit_price,(sod.quantity*purchase_table.rate) as purchase_price FROM(SELECT sales_order_details.order_no,sales_order_details.stock_id,sales_order_details.`quantity`,sales_order_details.`unit_price`,sales_order_details.`discount_percent`,sales_order_details.`tax_type_id` as tax_id FROM `sales_order_details` WHERE `trans_type`=202)sod
 				LEFT JOIN item_tax_types as tax
 				ON tax.id = sod.tax_id
 

--- a/database/migrations/2017_10_28_055005_alter_sales_orders_table_with_perOrderDiscount.php
+++ b/database/migrations/2017_10_28_055005_alter_sales_orders_table_with_perOrderDiscount.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+class AlterSalesOrdersTableWithPerOrderDiscount extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('sales_orders', function(Blueprint $table){
+            $table->tinyInteger('discount_type')->after('delivery_price')->default(1)->comment('1=Per Item, 2=Per Order');
+            $table->double('discount_percent')->after('discount_type')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('sales_orders', function(Blueprint $table){
+            $table->dropColumn('discount_type');
+            $table->dropColumn('discount_percent');
+        });
+    }
+}

--- a/resources/lang/en/message.php
+++ b/resources/lang/en/message.php
@@ -188,7 +188,8 @@ return [
         'add_new_supplier' => 'Add New Supplier',
         'branch_total'     => 'Branch',
         'delivery_price'   => 'Delivery Fee',
-        
+        'discount_type'   => 'Discount Type',
+
 
         'company'                     => 'Company',
         'db_host'                     => 'Database Host',

--- a/resources/views/admin/invoice/invoicePdf.blade.php
+++ b/resources/views/admin/invoice/invoicePdf.blade.php
@@ -111,17 +111,24 @@ tr{ height:40px;}
     $sum = $item['quantity']+$sum;
   ?>
   @endif
-  @endforeach  
+  @endforeach
+
+       <?php
+       $subTotalDiscount = ($subTotalAmount*$saleDataInvoice->discount_percent)/100;
+       $subTotalAmount = $subTotalAmount-$subTotalDiscount;
+       ?>
 
     <tr style="background-color:#fff; text-align:right; font-size:13px; font-weight:normal; height:100px;">
       <td colspan="6" style="border-bottom:none">
          Total Quantity<br />
+          <strong>Discount(%)</strong><br/>
        <strong>SubTotal</strong><br/>
        <strong>Delivery Fee</strong><br/>
         </td>   
 
       <td style="text-align:right; padding-right:10px;border-bottom:none">
         {{$sum}}<br />
+          {{number_format(($saleDataInvoice->discount_percent),2,'.',',')}}<br/>
        {{Session::get('currency_symbol').number_format(($subTotalAmount),2,'.',',')}}<br/>
        {{Session::get('currency_symbol').number_format(($saleDataInvoice->delivery_price),2,'.',',')}}<br/>
       </td>

--- a/resources/views/admin/invoice/invoicePrint.blade.php
+++ b/resources/views/admin/invoice/invoicePrint.blade.php
@@ -111,17 +111,24 @@ tr{ height:40px;}
     $sum = $item['quantity']+$sum;
   ?>
   @endif
-  @endforeach  
+  @endforeach
+
+       <?php
+       $subTotalDiscount = ($subTotalAmount*$saleDataInvoice->discount_percent)/100;
+       $subTotalAmount = $subTotalAmount-$subTotalDiscount;
+       ?>
 
     <tr style="background-color:#fff; text-align:right; font-size:13px; font-weight:normal; height:100px;">
       <td colspan="6" style="border-bottom:none">
          Total Quantity<br />
+       <strong>Discount(%)</strong><br/>
        <strong>SubTotal</strong><br/>
        <strong>Delivery Fee</strong><br/>
         </td>
 
       <td style="text-align:right; padding-right:10px;border-bottom:none">
         {{$sum}}<br />
+       {{number_format(($saleDataInvoice->discount_percent),2,'.',',')}}<br/>
        {{Session::get('currency_symbol').number_format(($subTotalAmount),2,'.',',')}}<br/>
        {{Session::get('currency_symbol').number_format(($saleDataInvoice->delivery_price),2,'.',',')}}<br/>
       </td>
@@ -162,7 +169,7 @@ tr{ height:40px;}
        @endif
        </strong></td>
     </tr>
-   </table> 
+   </table>
     </div>
   <script type="text/javascript">
       window.onload = function() { window.print(); }

--- a/resources/views/admin/invoice/viewInvoiceDetails.blade.php
+++ b/resources/views/admin/invoice/viewInvoiceDetails.blade.php
@@ -130,13 +130,20 @@
                                 $subTotal += $newPrice;
                                 $units += $result['quantity'];
                                 $itemsInformation .= '<div>'.$result['quantity'].'x'.' '.$result['description'].'</div>';
-                              ?>
+                                ?>
                               <td align="right">{{number_format($newPrice,2,'.',',') }}</td>
                             </tr>
                             @endif
                         @endforeach
+
+                       <?php
+                        $subTotalDiscount = ($subTotal*$saleDataInvoice->discount_percent)/100;
+                        $subTotal = $subTotal-$subTotalDiscount;
+                       ?>
+
                         <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.total_qty') }}</td><td align="right" colspan="2">{{$units}}</td></tr>
-                      <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.sub_total') }}</td><td align="right" colspan="2">{{ Session::get('currency_symbol').number_format($subTotal,2,'.',',') }}</td></tr>
+                       <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.discount') }}(%)</td><td align="right" colspan="2">{{ $saleDataInvoice->discount_percent }}</td></tr>
+                       <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.sub_total') }}</td><td align="right" colspan="2">{{ Session::get('currency_symbol').number_format($subTotal,2,'.',',') }}</td></tr>
                        <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.delivery_price') }}</td><td align="right" colspan="2">{{ Session::get('currency_symbol').number_format($saleDataInvoice->delivery_price,2,'.',',') }}</td></tr>
                       @foreach($taxType as $rate=>$tax_amount)
                       <?php

--- a/resources/views/admin/report/sales_history_report.blade.php
+++ b/resources/views/admin/report/sales_history_report.blade.php
@@ -71,8 +71,11 @@
             $duplicateResult = salesReportRemoveDuplicates($item->order_reference_id, $orderIdsArray);
             $orderIdsArray[] = $item->primary_order_no;
 
+            $salesTotalDiscount = ($item->sales_price_total*$item->order_discount_percent)/100;
+            $salesTotal = $item->sales_price_total-$salesTotalDiscount;
+
             //if($duplicateResult){
-                $profit = ($item->sales_price_total-$item->purch_price_amount-$item->tax);
+                $profit = ($salesTotal-$item->purch_price_amount-$item->tax);
 
                 if($item->purch_price_amount == 0){
                   $profit_margin = 100;
@@ -81,7 +84,7 @@
                 }
 
                 $qty_total += $item->qty;
-                $sales_total += $item->sales_price_total-$item->tax;
+                $sales_total += $salesTotal-$item->tax;
                 $cost_total += $item->purch_price_amount;
                 $tax_total += $item->tax;
                 $profit_total += $profit;
@@ -164,8 +167,11 @@
                 $duplicateResult = salesReportRemoveDuplicates($item->order_reference_id, $ordIdArray);
                 $ordIdArray[] = $item->primary_order_no;
 
+                $salesTotalDiscount = ($item->sales_price_total*$item->order_discount_percent)/100;
+                $salesTotal = $item->sales_price_total-$salesTotalDiscount;
+
                 //if($duplicateResult){
-                    $profit = ($item->sales_price_total-$item->purch_price_amount-$item->tax);
+                    $profit = ($salesTotal-$item->purch_price_amount-$item->tax);
 
                     if($item->purch_price_amount == 0){
                       $profit_margin = 100;
@@ -174,7 +180,7 @@
                     }
 
                     $qty += $item->qty;
-                    $sales_price += $item->sales_price_total;
+                    $sales_price += $salesTotal;
                     $purchase_price += $item->purch_price_amount;
                     $tax += $item->tax;
                     $total_profit += $profit
@@ -189,7 +195,7 @@
 
                       <td class="text-center"><a href="{{URL::to('/')}}/customer/edit/{{$item->debtor_no}}">{{ $item->name }}</a></td>
                       <td class="text-center">{{ $item->qty }}</td>
-                      <td class="text-center">{{ number_format(($item->sales_price_total-$item->tax),2,'.',',') }}</td>
+                      <td class="text-center">{{ number_format(($salesTotal-$item->tax),2,'.',',') }}</td>
                       <td class="text-center">{{ number_format(($item->purch_price_amount),2,'.',',') }}</td>
                       <td class="text-center">{{ number_format(($item->tax),2,'.',',') }}</td>
                       <td class="text-center">{{ number_format(($profit),2,'.',',') }}</td>

--- a/resources/views/admin/report/sales_report_by_date.blade.php
+++ b/resources/views/admin/report/sales_report_by_date.blade.php
@@ -29,9 +29,11 @@
             $duplicateResult = salesReportRemoveDuplicates($item->order_reference_id, $orderIdsArray);
             $orderIdsArray[] = $item->primary_order_no;
 
+                $salesTotalDiscount = ($item->sales_price_total*$item->order_discount_percent)/100;
+                $salesTotal = $item->sales_price_total-$salesTotalDiscount;
             //if($duplicateResult){
                 $qty_total += $item->qty;
-                $sales_total += $item->sales_price_total-$item->tax;
+                $sales_total += $salesTotal-$item->tax;
                 $cost_total += $item->purch_price_amount;
                 $tax_total += $item->tax;
                 $profit_amount = ($item->sales_price_total-$item->tax-$item->purch_price_amount);
@@ -111,7 +113,11 @@
 
                 //if($duplicateResult){
 
-                    $profit = ($item->sales_price_total-$item->tax-$item->purch_price_amount);
+                $salesTotalDiscount = ($item->sales_price_total*$item->order_discount_percent)/100;
+                $salesTotal = $item->sales_price_total-$salesTotalDiscount;
+
+
+                    $profit = ($salesTotal-$item->tax-$item->purch_price_amount);
 
                     if($item->purch_price_amount<=0){
                       $profit_margin = 100;
@@ -120,7 +126,7 @@
                     }
 
                     $qty += $item->qty;
-                    $sales_price += $item->sales_price_total;
+                    $sales_price += $salesTotal;
                     $purchase_price += $item->purch_price_amount;
                     $tax += $item->tax;
                     $total_profit += $profit;
@@ -135,7 +141,7 @@
 
                       <td class="text-center"><a href="{{URL::to('/')}}/customer/edit/{{$item->debtor_no}}">{{ $item->name }}</a></td>
                       <td class="text-center">{{ $item->qty }}</td>
-                      <td class="text-center">{{ number_format(($item->sales_price_total-$item->tax),2,'.',',') }}</td>
+                      <td class="text-center">{{ number_format(($salesTotal-$item->tax),2,'.',',') }}</td>
                       <td class="text-center">{{ number_format(($item->purch_price_amount),2,'.',',') }}</td>
                       <td class="text-center">{{ number_format(($item->tax),2,'.',',') }}</td>
                       <td class="text-center">{{ number_format(($profit),2,'.',',') }}</td>

--- a/resources/views/admin/sale/sale_edit.blade.php
+++ b/resources/views/admin/sale/sale_edit.blade.php
@@ -117,6 +117,24 @@
               <span id="errMsg" class="text-danger"></span>
             </div>
         </div>
+
+            <div class="row">
+
+                <div class="col-md-3">
+                    <div class="form-group">
+                        <label for="exampleInputEmail1">{{ trans('message.table.discount_type') }}</label>
+                        <select class="form-control select2" name="discount_type" id="discount_type" disabled>
+                            <option value="1" {{($saleData->discount_type==1) ? 'selected=selected' : ''}}>Per Item</option>
+                            <option value="2" {{($saleData->discount_type==2) ? 'selected=selected' : ''}}>Per Order</option>
+                        </select>
+                        <input type="hidden" name="discount_type" value="{{$saleData->discount_type}}" />
+                    </div>
+                </div>
+
+            </div>
+
+            <br>
+
         <div class="row">
           <div class="col-md-12">
             <div class="text-center" id="quantityMessage" style="color:red; font-weight:bold">
@@ -163,6 +181,8 @@
 
 
                     @endforeach
+
+                    <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.discount') }}(%)</strong></td><td align="left" colspan="2"><input type="text" class="form-control" id="perOrderDiscount" name="perOrderDiscount" value="{{$saleData->discount_percent}}" max="100" min="0" readonly></td></tr>
 
                   <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.sub_total') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="subTotal"></strong></td></tr>
 
@@ -301,6 +321,8 @@
 
       // Calculate subTotal
       var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
       $("#subTotal").html(subTotal);
 
         //Get Delivery Fee
@@ -379,6 +401,14 @@
         return result;
       }
 
+    //Calculate disccount for per order
+    function calculatePerOrderDiscount(total, discount){
+        var finalDiscount = (discount * total)/100;
+        var totalAfterDiscount = total - finalDiscount;
+
+        return totalAfterDiscount;
+    }
+
 // Item form validation
     $('#salesForm').validate({
         rules: {
@@ -405,6 +435,8 @@
 
     $(document).ready(function(){
         var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
         $("#subTotal").text(subTotal);
       });
 

--- a/resources/views/admin/salesOrder/createManualInvoice.blade.php
+++ b/resources/views/admin/salesOrder/createManualInvoice.blade.php
@@ -176,6 +176,7 @@
                     <?php
                       $tax = 0;
                     ?>
+                  <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.discount') }}(%)</strong></td><td align="left" colspan="2"><strong id="perOrderDiscount">{{$saleData->discount_percent}}</strong></td></tr>
                   <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.sub_total') }}</strong></td><td align="left" colspan="2"><strong id="subTotal"></strong></td></tr>
                   <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.delivery_price') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="deliveryFee">{{$saleData->delivery_price}}</strong></td></tr>
                   @foreach($taxType as $rate=>$tax_amount)
@@ -184,6 +185,11 @@
                       $tax += $tax_amount;
                     ?>
                   @endforeach
+
+                  <?php
+                  $subTotalDiscountPrice = ($totalPrice*$saleData->discount_percent)/100;
+                  $totalPrice = ($totalPrice-$subTotalDiscountPrice);
+                  ?>
 
                   <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.grand_total') }}</strong></td><td align="left" colspan="2"><input type='text' name="total" class="form-control" id = "grandTotal" value="{{$totalPrice+$tax+$saleData->delivery_price}}" readonly></td></tr>
                   @endif
@@ -214,6 +220,10 @@
     </section>
 @endsection
 @section('js')
+    <script type="text/javascript">
+        var perOrderPercentage = '<?php echo $saleData->discount_percent; ?>';
+    </script>
+
     <script type="text/javascript">
 
       var refNo ='INV-'+$("#reference_no").val();
@@ -319,7 +329,9 @@
 
       // Calculate subTotal
       var subTotal = calculateSubTotal();
-      $("#subTotal").html(subTotal);
+        var perOrderDiscount = parseFloat(perOrderPercentage);
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+        $("#subTotal").html(subTotal);
 
         //Get Delivery Fee
         var delivery_fee = parseFloat($("#delivery_price").val());
@@ -437,6 +449,8 @@
                $("tr.tax_rate_"+itemTaxRow).remove();
 
                 var subTotal = calculateSubTotal();
+               var perOrderDiscount = parseFloat(perOrderPercentage);
+               subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
                 $("#subTotal").html(subTotal);
 
                //Fetch delivery fee
@@ -450,7 +464,12 @@
             }
             
             var subTotal = calculateSubTotal();
+          var perOrderDiscount = parseFloat(perOrderPercentage);
+          subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
             $("#subTotal").html(subTotal);
+
+          //Fetch delivery fee
+          var deliveryFee = parseFloat($("#delivery_price").val());
             
             var newTaxInfo =createTaxId(itemTaxRow);
             var priceByTaxTpye = calculateTotalByTaxType(itemTaxRow); 
@@ -459,7 +478,7 @@
            
             var taxTotal = calculateTaxTotal();
             // Calculate GrandTotal
-            var grandTotal = (subTotal + taxTotal);
+            var grandTotal = (subTotal + taxTotal + deliveryFee);
             $("#grandTotal").val(grandTotal);           
           var count = $('#purchaseInvoice tr.insufficient').length;
           
@@ -476,6 +495,8 @@
 
     $(document).ready(function(){
         var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat(perOrderPercentage);
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
         $("#subTotal").text(subTotal);
       });
 

--- a/resources/views/admin/salesOrder/createManualInvoice.blade.php
+++ b/resources/views/admin/salesOrder/createManualInvoice.blade.php
@@ -111,6 +111,24 @@
             </div>
         </div>
 
+
+          <div class="row">
+
+              <div class="col-md-3">
+                  <div class="form-group">
+                      <label for="exampleInputEmail1">{{ trans('message.table.discount_type') }}</label>
+                      <select class="form-control select2" name="discount_type" id="discount_type" disabled>
+                          <option value="1" {{($saleData->discount_type==1) ? 'selected=selected' : ''}}>Per Item</option>
+                          <option value="2" {{($saleData->discount_type==2) ? 'selected=selected' : ''}}>Per Order</option>
+                      </select>
+                      <input type="hidden" name="discount_type" value="{{$saleData->discount_type}}" />
+                  </div>
+              </div>
+
+          </div>
+
+              <br>
+
         <div class="row">
           <div class="col-md-12">
             <div class="text-center" id="quantityMessage" style="color:red; font-weight:bold">
@@ -176,7 +194,7 @@
                     <?php
                       $tax = 0;
                     ?>
-                  <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.discount') }}(%)</strong></td><td align="left" colspan="2"><strong id="perOrderDiscount">{{$saleData->discount_percent}}</strong></td></tr>
+                  <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.discount') }}(%)</strong></td><td align="left" colspan="2"><input type="text" class="form-control" id="perOrderDiscount" name="perOrderDiscount" value="{{$saleData->discount_percent}}" max="100" min="0" readonly></td></tr>
                   <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.sub_total') }}</strong></td><td align="left" colspan="2"><strong id="subTotal"></strong></td></tr>
                   <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.delivery_price') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="deliveryFee">{{$saleData->delivery_price}}</strong></td></tr>
                   @foreach($taxType as $rate=>$tax_amount)

--- a/resources/views/admin/salesOrder/orderAdd.blade.php
+++ b/resources/views/admin/salesOrder/orderAdd.blade.php
@@ -104,6 +104,23 @@
           </div>   
         </div>
 
+
+        <div class="row">
+
+            <div class="col-md-3">
+                <div class="form-group">
+                    <label for="exampleInputEmail1">{{ trans('message.table.discount_type') }}</label>
+                    <select class="form-control select2" name="discount_type" id="discount_type">
+                        <option value="1">Per Item</option>
+                        <option value="2">Per Order</option>
+                    </select>
+                </div>
+            </div>
+
+        </div>
+
+        <br>
+
         <div class="row">
             <div class="col-md-6">
               <div class="form-group">
@@ -143,6 +160,7 @@
                     <th width="5%"  class="text-center">{{ trans('message.table.action') }}</th>
                   </tr>
 
+                  <tr class="tableInfo"><td colspan="6" align="right"><strong>{{ trans('message.table.discount') }}(%)</strong></td><td align="left" colspan="2"><input type="text" class="form-control" id="perOrderDiscount" name="perOrderDiscount" value="0" max="100" min="0" readonly></td></tr>
                   <tr class="tableInfo"><td colspan="6" align="right"><strong>{{ trans('message.table.sub_total') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="subTotal"></strong></td></tr>
                   <tr class="tableInfo"><td colspan="6" align="right"><strong>{{ trans('message.table.delivery_price') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="deliveryFee"></strong></td></tr>
                   <tr class="tableInfo"><td colspan="6" align="right"><strong>{{ trans('message.invoice.totalTax') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="taxTotal"></strong></td></tr>
@@ -204,7 +222,7 @@ $(function() {
       });
     });
 
-    
+
     $(document).on('keyup', '#reference_no', function () {
         var val = $(this).val();
 
@@ -315,7 +333,7 @@ $(function() {
                           '<td class="text-center"><input min="0"  type="text" class="form-control text-center unitprice" name="unit_price[]" data-id = "'+e.id+'" id="rate_id_'+e.id+'" value="'+ e.price +'"></td>'+
                           '<td class="text-center">'+ taxOptionList +'</td>'+
                           '<td class="text-center taxAmount">'+ taxAmount +'</td>'+
-                          '<td class="text-center"><input type="text" class="form-control text-center discount" name="discount[]" data-input-id="'+e.id+'" id="discount_id_'+e.id+'" max="100" min="0"></td>'+
+                          '<td class="text-center"><input type="text" class="form-control text-center discount" name="discount[]" data-input-id="'+e.id+'" id="discount_id_'+e.id+'" max="100" min="0" value="0"></td>'+
                           '<td><input class="form-control text-center amount" type="text" amount-id = "'+e.id+'" id="amount_'+e.id+'" value="'+e.price+'" name="item_price[]" readonly></td>'+
                           '<td class="text-center"><button id="'+e.id+'" class="btn btn-xs btn-danger delete_item"><i class="glyphicon glyphicon-trash"></i></button></td>'+
                           '</tr>';
@@ -329,6 +347,8 @@ $(function() {
 
                 // Calculate subtotal
                 var subTotal = calculateSubTotal();
+                var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+                subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
                 $("#subTotal").html(subTotal);
 
                 //Get Delivery Fee
@@ -378,6 +398,8 @@ $(function() {
 
                 // Calculate subTotal
                 var subTotal = calculateSubTotal();
+                var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+                subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
                 $("#subTotal").html(subTotal);
 
                   //Get Delivery Fee
@@ -400,7 +422,12 @@ $(function() {
               
               $(this).val('');
               $('#val_item').html('');
+
+              //To check what discount type option is selected
+              $("#discount_type").change();
+
               return false;
+
           }
         },
         minLength: 1,
@@ -480,6 +507,8 @@ $(function() {
 
       // Calculate subTotal
       var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
       $("#subTotal").html(subTotal);
 
         //Get Delivery Fee
@@ -524,6 +553,8 @@ $(function() {
 
       // Calculate subTotal
       var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
       $("#subTotal").html(subTotal);
 
         //Get Delivery Fee
@@ -569,6 +600,8 @@ $(function() {
 
       // Calculate subTotal
       var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
       $("#subTotal").html(subTotal);
         //Fetch delivery fee
         var deliveryFee = parseFloat($("#delivery_price").val());
@@ -592,6 +625,8 @@ $(function() {
 
         // Fetch subTotal
         var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
 
         //Set the value in delivery html
         $("#deliveryFee").html(deliveryFee);
@@ -617,7 +652,10 @@ $(function() {
 
       // Calculate subTotal
       var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
       $("#subTotal").html(subTotal);
+
         //Fetch delivery fee
         var deliveryFee = parseFloat($("#delivery_price").val());
 
@@ -646,6 +684,8 @@ $(function() {
            $("#rowid"+v+" .taxAmount").text(taxByRow);
 
             var subTotal = calculateSubTotal();
+            var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+            subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
             $("#subTotal").html(subTotal);
 
           //Fetch delivery fee
@@ -655,10 +695,47 @@ $(function() {
             $("#taxTotal").text(taxTotal);
             // Calculate GrandTotal
             var grandTotal = (subTotal + taxTotal + deliveryFee);
-            $("#grandTotal").val(grandTotal);           
+            $("#grandTotal").val(grandTotal);
 
         });
     });
+
+    //Discount type drop down on change
+    $(document).on('change', '#discount_type', function(){
+        if($(this).val()=='2') {
+            $('.discount').val(0);
+            //reclaculate the total calculation after exclude per item discount after setting per item discount 0
+            $('.discount').keyup();
+            $('.discount').attr('readonly', true);
+            $('#perOrderDiscount').attr('readonly', false);
+        }else{
+            $('.discount').attr('readonly', false);
+            $('#perOrderDiscount').val(0);
+            //reclaculate the total calculation after exclude per item discount after setting per item discount 0
+            $('.discount').keyup();
+            $('#perOrderDiscount').attr('readonly', true);
+        }
+    });
+
+    //per order discount key up event
+    $(document).on('keyup', '#perOrderDiscount', function(){
+
+        // Calculate subTotal
+        var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($(this).val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+        $("#subTotal").html(subTotal);
+        //Fetch delivery fee
+        var deliveryFee = parseFloat($("#delivery_price").val());
+        // Calculate taxTotal
+        var taxTotal = calculateTaxTotal();
+        $("#taxTotal").text(taxTotal);
+        // Calculate GrandTotal
+        var grandTotal = (subTotal + taxTotal + deliveryFee);
+        $("#grandTotal").val(grandTotal);
+
+    });
+
       
       /**
       * Calcualte Total tax
@@ -704,6 +781,22 @@ $(function() {
         var result = (p-discount); 
         return result;
       }
+
+    //Calculate disccount for per order
+    function calculatePerOrderDiscount(total, discount){
+        var finalDiscount = (discount * total)/100;
+        var totalAfterDiscount = total - finalDiscount;
+
+        return totalAfterDiscount;
+    }
+
+    //Calculation after excluding order discount
+    function excludeOrderDiscount(total, discount){
+        var finalDiscount = (discount * total)/100;
+        var totalAfterDiscount = total + finalDiscount;
+
+        return totalAfterDiscount;
+    }
 
 // Item form validation
     $('#salesForm').validate({

--- a/resources/views/admin/salesOrder/orderEdit.blade.php
+++ b/resources/views/admin/salesOrder/orderEdit.blade.php
@@ -134,6 +134,23 @@
               <span id="errMsg" class="text-danger"></span>
             </div>
         </div>
+
+        <div class="row">
+
+            <div class="col-md-3">
+                <div class="form-group">
+                    <label for="exampleInputEmail1">{{ trans('message.table.discount_type') }}</label>
+                    <select class="form-control select2" name="discount_type" id="discount_type">
+                        <option value="1" {{($saleData->discount_type==1) ? 'selected=selected' : ''}}>Per Item</option>
+                        <option value="2" {{($saleData->discount_type==2) ? 'selected=selected' : ''}}>Per Order</option>
+                    </select>
+                </div>
+            </div>
+
+        </div>
+
+        <br>
+
         <div class="row">
             <div class="col-md-6">
               <div class="form-group">
@@ -202,7 +219,7 @@
                             </select>
                           </td>
                           <td class="text-center taxAmount">{{$tax}}</td>
-                          <td class="text-center"><input class="form-control text-center discount" name="discount[]" data-input-id="{{$result->item_id}}" id="discount_id_{{$result->item_id}}" max="100" min="0" type="text" value="{{$result->discount_percent}}"></td>
+                          <td class="text-center"><input class="form-control text-center discount" name="discount[]" data-input-id="{{$result->item_id}}" id="discount_id_{{$result->item_id}}" max="100" min="0" type="text" value="{{$result->discount_percent}}" {{($saleData->discount_type==2) ? 'readonly' : ''}}></td>
 
                           <td><input amount-id="{{$result->item_id}}" class="form-control text-center amount" id="amount_{{$result->item_id}}" value="{{$newPrice}}" name="item_price[]" readonly type="text"></td>
                           <td class="text-center"><button id="{{$result->item_id}}" class="btn btn-xs btn-danger delete_item {{$deleteBtn}}"><i class="glyphicon glyphicon-trash"></i></button></td>
@@ -211,6 +228,7 @@
                     $stack[] = $result->item_id;
                   ?>
                     @endforeach
+                    <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.discount') }}(%)</strong></td><td align="left" colspan="2"><input type="text" class="form-control" id="perOrderDiscount" name="perOrderDiscount" value="{{$saleData->discount_percent}}" max="100" min="0" {{($saleData->discount_type==1) ? 'readonly' : ''}}></td></tr>
                   <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.sub_total') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="subTotal"></strong></td></tr>
                     <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.delivery_price') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="deliveryFee">{{$saleData->delivery_price}}</strong></td></tr>
                   <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.invoice.totalTax') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="taxTotal">{{$taxTotal}}</strong></td></tr>
@@ -382,7 +400,7 @@ $(function() {
                           '<td class="text-center"><input min="0"  type="text" class="form-control text-center unitprice" name="unit_price_new[]" data-id = "'+e.id+'" id="rate_id_'+e.id+'" value="'+ e.price +'"></td>'+
                           '<td class="text-center">'+ taxOptionList +'</td>'+
                           '<td class="text-center taxAmount">'+ taxAmount +'</td>'+
-                          '<td class="text-center"><input type="text" class="form-control text-center discount" name="discount_new[]" data-input-id="'+e.id+'" id="discount_id_'+e.id+'" max="100" min="0"></td>'+
+                          '<td class="text-center"><input type="text" class="form-control text-center discount" name="discount_new[]" data-input-id="'+e.id+'" id="discount_id_'+e.id+'" max="100" min="0" value="0"></td>'+
                           '<td><input class="form-control text-center amount" type="text" amount-id = "'+e.id+'" id="amount_'+e.id+'" value="'+e.price+'" name="item_price_new[]" readonly></td>'+
                           '<td class="text-center"><button id="'+e.id+'" class="btn btn-xs btn-danger delete_item"><i class="glyphicon glyphicon-trash"></i></button></td>'+
                           '</tr>';
@@ -396,6 +414,8 @@ $(function() {
 
                 // Calculate subtotal
                 var subTotal = calculateSubTotal();
+                var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+                subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
                 $("#subTotal").html(subTotal);
 
                   //Get Delivery Fee
@@ -443,6 +463,8 @@ $(function() {
 
                 // Calculate subTotal
                 var subTotal = calculateSubTotal();
+                var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+                subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
                 $("#subTotal").html(subTotal);
 
                   //Get Delivery Fee
@@ -463,6 +485,10 @@ $(function() {
               
               $(this).val('');
               $('#val_item').html('');
+
+              //To check what discount type option is selected
+              $("#discount_type").change();
+
               return false;
           }
         },
@@ -553,6 +579,8 @@ $(function() {
 
       // Calculate subTotal
       var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
       $("#subTotal").html(subTotal);
 
         //Get Delivery Fee
@@ -593,6 +621,8 @@ $(function() {
 
       // Calculate subTotal
       var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
       $("#subTotal").html(subTotal);
 
         //Get Delivery Fee
@@ -637,6 +667,8 @@ $(function() {
 
       // Calculate subTotal
       var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
       $("#subTotal").html(subTotal);
         //Fetch delivery fee
         var deliveryFee = parseFloat($("#delivery_price").val());
@@ -660,6 +692,8 @@ $(function() {
 
         // Fetch subTotal
         var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
 
         //Set the value in delivery html
         $("#deliveryFee").html(deliveryFee);
@@ -684,6 +718,8 @@ $(function() {
 
       // Calculate subTotal
       var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
       $("#subTotal").html(subTotal);
         //Fetch delivery fee
         var deliveryFee = parseFloat($("#delivery_price").val());
@@ -712,6 +748,8 @@ $(function() {
            $("#rowid"+v+" .taxAmount").text(taxByRow);
             
             var subTotal = calculateSubTotal();
+            var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+            subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
             $("#subTotal").html(subTotal);
 
           //Fetch delivery fee
@@ -724,6 +762,44 @@ $(function() {
             $("#grandTotal").val(grandTotal);           
 
         });
+
+    });
+
+
+    //Discount type drop down on change
+    $(document).on('change', '#discount_type', function(){
+        if($(this).val()=='2') {
+            $('.discount').val(0);
+            //reclaculate the total calculation after exclude per item discount after setting per item discount 0
+            $('.discount').keyup();
+            $('.discount').attr('readonly', true);
+            $('#perOrderDiscount').attr('readonly', false);
+        }else{
+            $('.discount').attr('readonly', false);
+            $('#perOrderDiscount').val(0);
+            //reclaculate the total calculation after exclude per item discount after setting per item discount 0
+            $('.discount').keyup();
+            $('#perOrderDiscount').attr('readonly', true);
+        }
+    });
+
+
+    //per order discount key up event
+    $(document).on('keyup', '#perOrderDiscount', function(){
+
+        // Calculate subTotal
+        var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($(this).val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+        $("#subTotal").html(subTotal);
+        //Fetch delivery fee
+        var deliveryFee = parseFloat($("#delivery_price").val());
+        // Calculate taxTotal
+        var taxTotal = calculateTaxTotal();
+        $("#taxTotal").text(taxTotal);
+        // Calculate GrandTotal
+        var grandTotal = (subTotal + taxTotal + deliveryFee);
+        $("#grandTotal").val(grandTotal);
 
     });
       
@@ -772,6 +848,23 @@ $(function() {
         return result;
       }
 
+
+    //Calculate disccount for per order
+    function calculatePerOrderDiscount(total, discount){
+        var finalDiscount = (discount * total)/100;
+        var totalAfterDiscount = total - finalDiscount;
+
+        return totalAfterDiscount;
+    }
+
+    //Calculation after excluding order discount
+    function excludeOrderDiscount(total, discount){
+        var finalDiscount = (discount * total)/100;
+        var totalAfterDiscount = total + finalDiscount;
+
+        return totalAfterDiscount;
+    }
+
 // Item form validation
     $('#salesForm').validate({
         rules: {
@@ -801,6 +894,8 @@ $(function() {
 
     $(document).ready(function(){
         var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
         $("#subTotal").text(subTotal);
       });
 

--- a/resources/views/admin/salesOrder/orderPdf.blade.php
+++ b/resources/views/admin/salesOrder/orderPdf.blade.php
@@ -96,17 +96,24 @@ tr{ height:40px;}
   <?php
     $sum = $item['quantity']+$sum;
   ?>
-  @endforeach   
+  @endforeach
+
+       <?php
+       $subTotalDiscountPrice = ($subTotalAmount*$saleData->discount_percent)/100;
+       $subTotalAmount = number_format(($subTotalAmount-$subTotalDiscountPrice), 2, '.', ',');
+       ?>
 
     <tr style="background-color:#fff; text-align:right; font-size:13px; font-weight:normal; height:100px;">
       <td colspan="6" style="border-bottom:none">
          Total Quantity<br />
+          <strong>Discount(%)</strong><br/>
        <strong>SubTotal</strong><br/>
         <strong>Delivery Fee</strong><br/>
         </td>   
 
       <td style="text-align:right; padding-right:10px;border-bottom:none">
         {{$sum}}<br />
+          {{number_format(($saleData->discount_percent),2,'.',',')}}<br/>
        {{Session::get('currency_symbol').number_format(($subTotalAmount),2,'.',',')}}<br/>
           {{Session::get('currency_symbol').number_format(($saleData->delivery_price),2,'.',',')}}<br/>
       </td>

--- a/resources/views/admin/salesOrder/orderPrint.blade.php
+++ b/resources/views/admin/salesOrder/orderPrint.blade.php
@@ -114,17 +114,24 @@ tr{ height:40px;}
   <?php
     $sum = $item['quantity']+$sum;
   ?>
-  @endforeach   
+  @endforeach
+
+       <?php
+       $subTotalDiscountPrice = ($subTotalAmount*$saleData->discount_percent)/100;
+       $subTotalAmount = number_format(($subTotalAmount-$subTotalDiscountPrice), 2, '.', ',');
+       ?>
 
     <tr style="background-color:#fff; text-align:right; font-size:13px; font-weight:normal; height:100px;">
       <td colspan="6" style="border-bottom:none">
          Total Quantity<br />
+       <strong>Discount(%)</strong><br/>
        <strong>SubTotal</strong><br/>
        <strong>Delivery Fee</strong><br/>
         </td>
 
       <td style="text-align:right; padding-right:10px;border-bottom:none">
         {{$sum}}<br />
+       {{number_format(($saleData->discount_percent),2,'.',',')}}<br/>
        {{Session::get('currency_symbol').number_format(($subTotalAmount),2,'.',',')}}<br/>
        {{Session::get('currency_symbol').number_format(($saleData->delivery_price),2,'.',',')}}<br/>
       </td>

--- a/resources/views/admin/salesOrder/viewOrderDetails.blade.php
+++ b/resources/views/admin/salesOrder/viewOrderDetails.blade.php
@@ -113,7 +113,12 @@
                                 <td align="right">{{ number_format($newPrice,2,'.',',') }}</td>
                               </tr>
                           @endforeach
+                         <?php
+                            $subTotalDiscountPrice = ($subTotal*$saleData->discount_percent)/100;
+                            $subTotal = number_format(($subTotal-$subTotalDiscountPrice), 2, '.', ',');
+                         ?>
                           <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.total_qty') }}</td><td align="right" colspan="2">{{$units}}</td></tr>
+                         <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.discount') }}(%)</td><td align="right" colspan="2">{{ $saleData->discount_percent }}</td></tr>
                         <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.sub_total') }}</td><td align="right" colspan="2">{{ Session::get('currency_symbol').number_format($subTotal,2,'.',',') }}</td></tr>
                          <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.delivery_price') }}</td><td align="right" colspan="2">{{ Session::get('currency_symbol').number_format($saleData->delivery_price,2,'.',',') }}</td></tr>
                         @foreach($taxType as $rate=>$tax_amount)

--- a/resources/views/admin/salesOrder/viewOrderDetails.blade.php
+++ b/resources/views/admin/salesOrder/viewOrderDetails.blade.php
@@ -119,8 +119,8 @@
                          ?>
                           <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.total_qty') }}</td><td align="right" colspan="2">{{$units}}</td></tr>
                          <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.discount') }}(%)</td><td align="right" colspan="2">{{ $saleData->discount_percent }}</td></tr>
-                        <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.sub_total') }}</td><td align="right" colspan="2">{{ Session::get('currency_symbol').number_format($subTotal,2,'.',',') }}</td></tr>
-                         <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.delivery_price') }}</td><td align="right" colspan="2">{{ Session::get('currency_symbol').number_format($saleData->delivery_price,2,'.',',') }}</td></tr>
+                        <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.sub_total') }}</td><td align="right" colspan="2">{{ Session::get('currency_symbol').$subTotal }}</td></tr>
+                         <tr class="tableInfos"><td colspan="5" align="right">{{ trans('message.table.delivery_price') }}</td><td align="right" colspan="2">{{ Session::get('currency_symbol').($saleData->delivery_price ? (number_format($saleData->delivery_price,2,'.',',')): '') }}</td></tr>
                         @foreach($taxType as $rate=>$tax_amount)
                         @if($rate != 0)
                         <tr><td colspan="5" align="right">Plus Tax({{$rate}}%)</td><td colspan="2" class="text-right">{{ Session::get('currency_symbol').number_format($tax_amount,2,'.',',') }}</td></tr>

--- a/resources/views/admin/shipment/createShipment.blade.php
+++ b/resources/views/admin/shipment/createShipment.blade.php
@@ -123,6 +123,7 @@
                         @endif
                     @endforeach
 
+                    <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.discount') }}(%)</strong></td><td align="left" colspan="2"><strong id="perOrderDiscount">{{$orderInfo->discount_percent}}</strong></td></tr>
                   <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.sub_total') }}</strong></td><td align="left" colspan="2"><strong id="subTotal"></strong></td></tr>
                   <?php
                  
@@ -136,6 +137,12 @@
                   ?>
                   @endif
                   @endforeach
+
+                    <?php
+                    $subTotalDiscountPrice = ($subTotalAmount*$orderInfo->discount_percent)/100;
+                    $subTotalAmount = ($subTotalAmount-$subTotalDiscountPrice);
+                    ?>
+
                   <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.grand_total') }}</strong></td><td align="left" colspan="2"><input type='text' class="form-control" id = "grandTotal" value="{{($subTotalAmount+$taxAmount)}}" readonly></td></tr>
                   @endif
                   </tbody>
@@ -164,6 +171,11 @@
     </section>
 @endsection
 @section('js')
+
+    <script type="text/javascript">
+        var perOrderPercentage = '<?php echo $orderInfo->discount_percent; ?>';
+    </script>
+
     <script type="text/javascript">
 
     $(function () {
@@ -218,6 +230,8 @@
 
       // Calculate subTotal
       var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat(perOrderPercentage);
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
       $("#subTotal").html(subTotal);
       // Calculate taxTotal
       var taxTotal = calculateTaxTotal();

--- a/resources/views/admin/shipment/createShipment.blade.php
+++ b/resources/views/admin/shipment/createShipment.blade.php
@@ -124,18 +124,20 @@
                     @endforeach
 
                     <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.discount') }}(%)</strong></td><td align="left" colspan="2"><strong id="perOrderDiscount">{{$orderInfo->discount_percent}}</strong></td></tr>
-                  <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.sub_total') }}</strong></td><td align="left" colspan="2"><strong id="subTotal"></strong></td></tr>
+                  <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.sub_total') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="subTotal"></strong></td></tr>
+                    <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.delivery_price') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="deliveryFee">{{$orderInfo->delivery_price}}</strong></td></tr>
                   <?php
                  
                     $taxAmount = 0;
                   ?>
+
                   @foreach($taxType as $rate=>$tax_amount)
-                  @if(in_array($rate,$taxArray))
+                  {{--@if(in_array($rate,$taxArray))--}}
                   <tr class="tax_rate_{{str_replace('.','_',$rate)}}"><td colspan="6" align="right">{{ trans('message.invoice.plus_tax') }}({{$rate}}%)</td><td colspan="2" class="item-taxs" id="totalTaxs_{{str_replace('.','_',$rate)}}">{{$tax_amount}}</td></tr>
                   <?php
                     $taxAmount += $tax_amount;
                   ?>
-                  @endif
+                  {{--@endif--}}
                   @endforeach
 
                     <?php
@@ -309,6 +311,8 @@
 
     $(document).ready(function(){
         var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat(perOrderPercentage);
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
         $("#subTotal").text(subTotal);
       });
 

--- a/resources/views/admin/shipment/editShipment.blade.php
+++ b/resources/views/admin/shipment/editShipment.blade.php
@@ -92,6 +92,13 @@
                                   <td><input amount-id="{{$result->item_id}}" class="form-control text-center amount tax_item_price_{{$result->tax_rate}}" id="amount_{{$result->item_id}}" value="{{$discountPriceAmount}}" data-tax-rate="{{$result->tax_rate}}" readonly type="text"></td>
                                 </tr>
                         @endforeach
+
+                      <?php
+                        $subTotalDiscountPrice = ($subTotalAmount*$orderInfo->discount_percent)/100;
+                        $subTotalAmount = ($subTotalAmount-$subTotalDiscountPrice);
+                      ?>
+
+                      <tr class="tableInfos"><td colspan="5" align="right"><strong>{{ trans('message.table.discount') }}(%)</strong></td><td align="center" colspan="2"><strong id="perOrderDiscount">{{$orderInfo->discount_percent}}</strong></td></tr>
                       <tr class="tableInfos"><td colspan="5" align="right"><strong>{{ trans('message.table.sub_total') }}</strong></td><td align="center" colspan="2"><strong id="subTotal"></strong></td></tr>
                         @foreach($taxInfo as $rate=>$tax_amount)
                         <tr class="tax_rate_{{str_replace('.','_',$rate)}}">
@@ -124,6 +131,11 @@
     </section>
 @endsection
 @section('js')
+
+    <script type="text/javascript">
+        var perOrderPercentage = '<?php echo $orderInfo->discount_percent; ?>';
+    </script>
+
     <script type="text/javascript">
     var token = $("#token").val();
     var shipmentId= $("#shipment_id").val();
@@ -172,6 +184,8 @@
 
       // Calculate subTotal
       var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat(perOrderPercentage);
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
       $("#subTotal").html(subTotal);
       // Calculate taxTotal
       var taxTotal = calculateTaxTotal();
@@ -246,6 +260,8 @@
 
     $(document).ready(function(){
         var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat(perOrderPercentage);
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
         $("#subTotal").text(subTotal);
       });
     </script>

--- a/resources/views/admin/shipment/shipmentDetailPrint.blade.php
+++ b/resources/views/admin/shipment/shipmentDetailPrint.blade.php
@@ -98,16 +98,23 @@ tr{ height:40px;}
   <?php
     $sum = $item->quantity+$sum;
   ?>
-  @endforeach  
+  @endforeach
+
+       <?php
+        $subTotalDiscountPrice = ($subTotalAmount*$customerInfo->discount_percent)/100;
+        $subTotalAmount = ($subTotalAmount-$subTotalDiscountPrice);
+       ?>
 
     <tr style="background-color:#fff; text-align:right; font-size:13px; font-weight:normal; height:100px;">
       <td colspan="6" style="border-bottom:none">
          Total Quantity<br />
+       <strong>Discount(%)</strong><br/>
        <strong>SubTotal</strong><br/>
-        </td>   
+        </td>
 
       <td style="text-align:right; padding-right:10px;border-bottom:none">
         {{$sum}}<br />
+       {{$customerInfo->discount_percent}}<br/>
        {{Session::get('currency_symbol').number_format(($subTotalAmount),2,'.',',')}}<br/>
       </td>
     </tr>

--- a/resources/views/admin/shipment/shipmentDetailpdf.blade.php
+++ b/resources/views/admin/shipment/shipmentDetailpdf.blade.php
@@ -100,16 +100,23 @@ tr{ height:40px;}
   <?php
     $sum = $item->quantity+$sum;
   ?>
-  @endforeach  
+  @endforeach
+
+       <?php
+        $subTotalDiscountPrice = ($subTotalAmount*$customerInfo->discount_percent)/100;
+        $subTotalAmount = ($subTotalAmount-$subTotalDiscountPrice);
+       ?>
 
     <tr style="background-color:#fff; text-align:right; font-size:13px; font-weight:normal; height:100px;">
       <td colspan="6" style="border-bottom:none">
          Total Quantity<br />
+          <strong>Discount(%)</strong><br/>
        <strong>SubTotal</strong><br/>
         </td>   
 
       <td style="text-align:right; padding-right:10px;border-bottom:none">
         {{$sum}}<br />
+          {{$customerInfo->discount_percent}}<br/>
        {{Session::get('currency_symbol').number_format(($subTotalAmount),2,'.',',')}}<br/>
       </td>
     </tr>

--- a/resources/views/admin/shipment/shipmentDetails.blade.php
+++ b/resources/views/admin/shipment/shipmentDetails.blade.php
@@ -122,7 +122,15 @@
                             </tr>
                             @endif
                             @endforeach
+
+                            <?php
+                                $subtotalDiscount = ($subTotalAmount*$orderInfo->discount_percent)/100;
+                                $subTotalAmount = $subTotalAmount-$subtotalDiscount;
+                            ?>
                             <tr><td colspan="6" align="right">{{ trans('message.table.total_quantity') }}</td><td align="right">{{$qtyTotal}}</td></tr>
+
+                            <tr><td colspan="6" align="right"><strong>{{ trans('message.table.discount') }}(%)</strong></td><td align="right" colspan="2"><strong id="perOrderDiscount">{{$orderInfo->discount_percent}}</strong></td></tr>
+
                             <tr><td colspan="6" align="right"><strong>{{ trans('message.table.sub_total') }}</strong></td><td align="right"><strong>{{ Session::get('currency_symbol').number_format($subTotalAmount,2,'.',',') }}</strong></td></tr>
                             
                             @foreach($taxInfo as $rate=>$tax_amount)

--- a/resources/views/layouts/includes/script.blade.php
+++ b/resources/views/layouts/includes/script.blade.php
@@ -246,6 +246,14 @@ $("#notifications").fadeTo(2000, 500).slideUp(500, function(){
     $("#notifications").slideUp(500);
 });
 
+  //Calculate disccount for per order
+  function calculatePerOrderDiscount(total, discount){
+      var finalDiscount = (discount * total)/100;
+      var totalAfterDiscount = total - finalDiscount;
+
+      return totalAfterDiscount;
+  }
+
 // Google analytics start
 
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Enable discount per total of Sales Order (based on total, not item-by-item) 
-Right now Discount get applied on each Item of Order. So do we have to remove it and have new Discount field for entire Order? If so then we have to make changes at every place the Order, Invoices etc where Discount comes into picture. Please let us know that we are on same page or not.

—Please enable Discount for every item OR for whole order. So you can choose to add discount for every item or the whole order.
