### PR TITLE
Feature/order return

### DIFF
--- a/app/Http/Controllers/SalesOrderController.php
+++ b/app/Http/Controllers/SalesOrderController.php
@@ -13,8 +13,20 @@ use DB;
 use PDF;
 use Session;
 
+/**
+ * Class SalesOrderController
+ *
+ * @package App\Http\Controllers
+ */
 class SalesOrderController extends Controller
 {
+    /**
+     * @param \App\Model\Orders                       $orders
+     * @param \App\Model\Sales                        $sales
+     * @param \App\Model\Shipment                     $shipment
+     * @param \App\Http\Controllers\EmailController   $email
+     * @param \App\Http\Controllers\PaymentController $paymentController
+     */
     public function __construct(Orders $orders, Sales $sales, Shipment $shipment, EmailController $email, PaymentController $paymentController)
     {
         /**
@@ -392,6 +404,193 @@ class SalesOrderController extends Controller
         return redirect()->intended('order/view-order-details/' . $order_no);
     }
 
+
+    /**
+     * Functionality to return your order
+     * @param $orderNo
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     */
+    public function order_return($orderNo)
+    {
+        $data['menu']         = 'sales';
+        $data['sub_menu']     = 'order/list';
+        $data['taxType']      = $this->order->calculateTaxRow($orderNo);
+        $data['customerData'] = DB::table('debtors_master')->get();
+        $data['locData']      = DB::table('location')->get();
+        $data['invoiceData']  = $this->order->getSalseInvoiceByID($orderNo);
+        $data['saleData']     = DB::table('sales_orders')->where('order_no', '=', $orderNo)->first();
+        $data['branchs']      = DB::table('cust_branch')->select('debtor_no', 'branch_code', 'br_name')->where('debtor_no', $data['saleData']->debtor_no)->orderBy('br_name', 'ASC')->get();
+        $data['payments']     = DB::table('payment_terms')->get();
+        $data['invoicedItem'] = DB::table('stock_moves')->where(['order_no' => $orderNo])->lists('stock_id');
+        $data['salesType']    = DB::table('sales_types')->select('sales_type', 'id')->get();
+
+        //d($data['invoiceData'],1);
+
+        $taxTypeList = DB::table('item_tax_types')->get();
+        $taxOptions  = '';
+        $selectStart = "<select class='form-control taxList' name='tax_id_new[]'>";
+        $selectEnd   = "</select>";
+
+        foreach ($taxTypeList as $key => $value) {
+            $taxOptions .= "<option value='" . $value->id . "' taxrate='" . $value->tax_rate . "'>" . $value->name . '(' . $value->tax_rate . ')' . "</option>";
+        }
+        $data['tax_type_new'] = $selectStart . $taxOptions . $selectEnd;
+        $data['tax_types']    = $taxTypeList;
+
+        return view('admin.salesOrder.orderReturn', $data);
+    }
+
+
+
+    /**
+     * Order return save into the databse and manage inventory as per the same
+     * Update the specified resource in storage.
+     **/
+    public function update_orderReturn(Request $request)
+    {
+        $userId   = \Auth::user()->id;
+        $order_no = $request->order_no;
+        $this->validate($request, [
+            'from_stk_loc' => 'required',
+            'ord_date'     => 'required',
+            'debtor_no'    => 'required',
+            'branch_id'    => 'required',
+            'payment_id'   => 'required'
+        ]);
+
+        $itemQty      = $request->item_quantity;
+        $itemIds      = $request->item_id;
+        $unitPrice    = $request->unit_price;
+        $taxIds       = $request->tax_id;
+        $itemDiscount = $request->discount;
+        $itemPrice    = $request->item_price;
+        $stock_id     = $request->stock_id;
+        $description  = $request->description;
+
+        // update sales_order table
+        $salesOrder['ord_date']   = DbDateFormat($request->ord_date);
+        $salesOrder['debtor_no']  = $request->debtor_no;
+        $salesOrder['trans_type'] = SALESORDER;
+        $salesOrder['branch_id']  = $request->branch_id;
+        $salesOrder['payment_id'] = $request->payment_id;
+
+        $salesOrder['from_stk_loc'] = $request->from_stk_loc;
+        $salesOrder['comments']     = $request->comments;
+        $salesOrder['total']        = $request->total;
+        $salesOrder['delivery_price']        = $request->delivery_price;
+        $salesOrder['discount_type']        = $request->discount_type;
+        $salesOrder['discount_percent']        = $request->perOrderDiscount;
+        $salesOrder['paid_amount']        = $request->downpayment;
+        $salesOrder['updated_at']   = date('Y-m-d H:i:s');
+        //d($salesOrder,1);
+
+        DB::table('sales_orders')->where('order_no', $order_no)->update($salesOrder);
+
+        //Insert the record into the payment table while select downpayment in creating sales order
+        if($request->downpayment > 0) {
+            $this->paymentController->payAllAmount($order_no, $request->downpayment, true);
+            $salesOrderDebit['debit_amount'] = $request->total - $request->downpayment;
+            //;$currentCredit = $customerData[0]->total_credit;
+            //Update sales order table
+            DB::table('sales_orders')->where('order_no', $order_no)->update($salesOrderDebit);
+        }
+
+        //Update sales order when grand total is a negative value and it should treated as credit value
+        if($request->total < 0){
+            $salesOrderCredit['credit_amount'] = abs($request->total);
+            DB::table('sales_orders')->where('order_no', $order_no)->update($salesOrderCredit);
+        }
+
+
+        if (count($itemQty) > 0) {
+            $invoiceData = $this->order->getSalseInvoiceByID($order_no);
+            $invoiceData = objectToArray($invoiceData);
+
+            for ($i = 0; $i < count($invoiceData); $i++) {
+                if (!in_array($invoiceData[$i]['item_id'], $itemIds)) {
+                    DB::table('sales_order_details')->where([['order_no', '=', $invoiceData[$i]['order_no']], ['stock_id', '=', $invoiceData[$i]['stock_id']],])->delete();
+                }
+            }
+
+
+            foreach ($itemQty as $key => $value) {
+                $product[$itemIds[$key]] = $value;
+            }
+
+            for ($i = 0; $i < count($itemIds); $i++) {
+                foreach ($product as $key => $value) {
+                    if ($itemIds[$i] == $key) {
+
+                        // update sales_order_details table
+                        $salesOrderDetail[$i]['stock_id']         = $stock_id[$i];
+                        $salesOrderDetail[$i]['description']      = $description[$i];
+                        $salesOrderDetail[$i]['unit_price']       = $unitPrice[$i];
+                        $salesOrderDetail[$i]['qty_sent']         = $value;
+                        $salesOrderDetail[$i]['trans_type']       = SALESORDER;
+                        $salesOrderDetail[$i]['quantity']         = $value;
+                        $salesOrderDetail[$i]['discount_percent'] = $itemDiscount[$i];
+                    }
+                }
+            }
+            // d($salesOrderDetail,1);
+            for ($i = 0; $i < count($salesOrderDetail); $i++) {
+                DB::table('sales_order_details')->where(['stock_id' => $salesOrderDetail[$i]['stock_id'], 'order_no' => $order_no])->update($salesOrderDetail[$i]);
+
+            }
+
+        } else {
+            $invoiceData = $this->order->getSalseInvoiceByID($order_no);
+            $invoiceData = objectToArray($invoiceData);
+
+            for ($i = 0; $i < count($invoiceData); $i++) {
+                DB::table('sales_order_details')->where([['order_no', '=', $invoiceData[$i]['order_no']], ['stock_id', '=', $invoiceData[$i]['stock_id']],])->delete();
+            }
+            DB::table('sales_orders')->where('order_no', '=', $order_no)->delete();
+        }
+
+        if (isset($request->item_quantity_new)) {
+            $itemQty         = $request->item_quantity_new;
+            $itemIdsNew      = $request->item_id_new;
+            $unitPriceNew    = $request->unit_price_new;
+            $taxIdsNew       = $request->tax_id_new;
+            $itemDiscountNew = $request->discount_new;
+            $itemPriceNew    = $request->item_price_new;
+            $descriptionNew  = $request->description_new;
+            $stock_id_new    = $request->stock_id_new;
+
+            foreach ($itemQty as $key => $newItem) {
+                $productNew[$itemIdsNew[$key]] = $newItem;
+            }
+
+            for ($i = 0; $i < count($itemIdsNew); $i++) {
+                foreach ($productNew as $key => $value) {
+                    if ($itemIdsNew[$i] == $key) {
+
+                        // Insert new sales order detail
+                        $salesOrderDetailNew[$i]['trans_type']       = SALESORDER;
+                        $salesOrderDetailNew[$i]['order_no']         = $order_no;
+                        $salesOrderDetailNew[$i]['stock_id']         = $stock_id_new[$i];
+                        $salesOrderDetailNew[$i]['description']      = $descriptionNew[$i];
+                        $salesOrderDetailNew[$i]['qty_sent']         = $value;
+                        $salesOrderDetailNew[$i]['quantity']         = $value;
+                        $salesOrderDetailNew[$i]['discount_percent'] = $itemDiscountNew[$i];
+                        $salesOrderDetailNew[$i]['tax_type_id']      = $taxIdsNew[$i];
+                        $salesOrderDetailNew[$i]['unit_price']       = $itemPriceNew[$i];
+                    }
+                }
+            }
+            // d($salesOrderDetail,1);
+            for ($i = 0; $i < count($salesOrderDetailNew); $i++) {
+
+                DB::table('sales_order_details')->insertGetId($salesOrderDetailNew[$i]);
+            }
+        }
+
+        \Session::flash('success', trans('message.success.save_success'));
+        return redirect()->intended('order/view-order-details/' . $order_no);
+    }
+
+
     /**
      * Remove the specified resource from storage.
      **/
@@ -428,6 +627,9 @@ class SalesOrderController extends Controller
         }
     }
 
+    /**
+     * @param \Illuminate\Http\Request $request
+     */
     public function search(Request $request)
     {
 
@@ -1018,6 +1220,10 @@ class SalesOrderController extends Controller
         return $pdf->download('order_' . time() . '.pdf', array("Attachment" => 0));
     }
 
+    /**
+     * @param $orderNo
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     */
     public function orderPrint($orderNo)
     {
         $data['taxInfo']      = $this->sale->calculateTaxRow($orderNo);

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -168,6 +168,9 @@
 		Route::get('order/view-order/{id}','SalesOrderController@viewOrder');
 		Route::post('order/convert-order','SalesOrderController@convertOrder');
 
+		Route::get('order/return/{id}','SalesOrderController@order_return');
+		Route::post('order/returnUpdate','SalesOrderController@update_orderReturn');
+
 		Route::post('order/search','SalesOrderController@search');
 		Route::post('order/quantity-validation','SalesOrderController@quantityValidation');
 

--- a/resources/lang/en/message.php
+++ b/resources/lang/en/message.php
@@ -721,6 +721,8 @@ return [
     'payment_success'         => 'Payments completed successfully',
     'all'                     => 'All',
     'filter'                  => 'Filter',
+    'order_return'                  => 'Order Return',
+
 
 ],
       'purchase_report' =>[

--- a/resources/views/admin/salesOrder/orderReturn.blade.php
+++ b/resources/views/admin/salesOrder/orderReturn.blade.php
@@ -1,0 +1,1066 @@
+@extends('layouts.app')
+@section('content')
+    <!-- Main content -->
+    <section class="content">
+      <!-- Default box -->
+    <div class="row">
+      <div class="col-md-12">
+        <div class="box box-default">
+           <div class="box-header">
+              <h4 class="text-info ">{{ trans('message.table.order_no')}} # <a href="{{url('order/view-order-details/'.$saleData->order_no)}}">{{$saleData->reference}}</a></h4>
+            </div>
+        <!-- /.box-header -->
+        <div class="box-body">
+
+        <form action="{{url('order/returnUpdate')}}" method="POST" id="salesForm">
+        <input type="hidden" value="{{csrf_token()}}" name="_token" id="token">
+        <input type="hidden" value="{{$saleData->order_no}}" name="order_no" id="order_no">
+        <input type="hidden" value="{{$saleData->reference}}" id="reference">
+        <div class="row">
+            <div class="col-md-3">
+              <div class="form-group">
+                <label for="exampleInputEmail1">{{ trans('message.form.customer') }}</label>
+                <select class="form-control select2" name="debtor_no" id="customer" <?= !empty($invoicedItem) ? 'disabled' : ''?>>
+                <option value="">{{ trans('message.form.select_one') }}</option>
+                @foreach($customerData as $data)
+                  <option value="{{$data->debtor_no}}" <?= ($data->debtor_no == $saleData->debtor_no) ? 'selected' : ''?> >{{$data->name}}</option>
+                @endforeach
+                </select>
+
+                @if(!empty($invoicedItem))
+                  <input type="hidden" value="{{$saleData->debtor_no}}" name="debtor_no">
+                @endif
+
+              </div>
+            </div>
+            <div class="col-md-3">
+              <!-- /.form-group -->
+              <div class="form-group">
+                <label for="exampleInputEmail1">{{ trans('message.form.customer_branch') }}</label>
+                <select class="form-control select2" name="branch_id" id="branch" <?= !empty($invoicedItem) ? 'disabled' : ''?>>
+                <option value="">{{ trans('message.form.select_one') }}</option>
+                @if(!empty($branchs))
+                  @foreach($branchs as $branch)
+                  <option value="{{$branch->branch_code}}" <?= ($branch->branch_code == $saleData->branch_id ? 'selected':'')?>>{{$branch->br_name}}</option>
+                  @endforeach
+                @endif
+                </select>
+                @if(!empty($invoicedItem))
+                  <input type="hidden" value="{{$saleData->branch_id}}" name="branch_id">
+                @endif
+
+              </div>
+              <!-- /.form-group -->
+            </div>              
+
+            <div class="col-md-3">
+              <div class="form-group">
+                  <label for="exampleInputEmail1">{{ trans('message.form.from_location') }}</label>
+                    <select class="form-control select2" name="from_stk_loc" id="loc" <?= !empty($invoicedItem) ? 'disabled' : ''?>>
+                    
+                    @foreach($locData as $data)
+                      <option value="{{$data->loc_code}}" <?= ($data->loc_code == $saleData->from_stk_loc ? 'selected':'')?>>{{$data->location_name}}</option>
+                    @endforeach
+                    
+                    </select>
+
+                @if(!empty($invoicedItem))
+                  <input type="hidden" value="{{$saleData->from_stk_loc}}" name="from_stk_loc">
+                @endif
+
+              </div>
+            </div>
+
+            <div class="col-md-3">
+              <div class="form-group">
+                <label>{{ trans('message.table.date') }}<span class="text-danger"> *</span></label>
+                <div class="input-group date">
+                  <div class="input-group-addon">
+                    <i class="fa fa-calendar"></i>
+                  </div>
+                  <input readonly class="form-control" id="datepickers" type="text" name="ord_date" value="<?= isset($saleData->ord_date) ? formatDate($saleData->ord_date) :'' ?>">
+                </div>
+                <!-- /.input group -->
+              </div>
+            </div>
+            <div class="col-md-3">
+              <div class="form-group">
+                  <label for="exampleInputEmail1">{{ trans('message.extra_text.payment_method') }}</label>
+                     <select class="form-control select2" name="payment_id" <?= !empty($invoicedItem) ? 'disabled' : ''?>>
+                   
+                    @foreach($payments as $payment)
+                      <option value="{{$payment->id}}" <?= ($payment->id == $saleData->payment_id) ? 'selected' : ''?>>{{$payment->name}}</option>
+                    @endforeach
+                    </select>
+                @if(!empty($invoicedItem))
+                  <input type="hidden" value="{{$saleData->payment_id}}" name="payment_id">
+                @endif
+              </div>
+            </div>
+
+            <div class="col-md-3">
+              <div class="form-group">
+                  <label for="exampleInputEmail1">{{ trans('message.form.sales_type') }}</label>
+                     <select class="form-control select2" name="sales_type" id="sales_type_id">
+                   
+                    @foreach($salesType as $key=>$saleType)
+                      <option value="{{$saleType->id}}" <?= ($saleType->id== 1 )?'selected':''?>>{{$saleType->sales_type}}</option>
+                    @endforeach
+                    </select>
+              </div>
+            </div>
+
+
+            <div class="col-md-3">
+                <div class="form-group">
+                    <label for="exampleInputEmail1">{{ trans('message.table.delivery_price') }}</label>
+                    <input class="form-control delivery_price" id="delivery_price" type="text" name="delivery_price" value="{{$saleData->delivery_price}}">
+                </div>
+            </div>
+
+
+            <div class="col-md-3">
+              <div class="form-group">
+                  <label for="exampleInputEmail1">{{ trans('message.table.reference') }}<span class="text-danger"> *</span></label>
+                  <?php
+                    $refArray = explode('-',$saleData->reference);
+                  ?>
+                <div class="input-group">
+                   <div class="input-group-addon">SO-</div>
+                   <input id="reference_no" class="form-control" value="<?= isset($refArray[1]) ? $refArray[1] :'' ?>" type="text" readonly>
+                   <input type="hidden"  name="reference" id="reference_no_write" value="">
+                </div>
+              </div>
+              <span id="errMsg" class="text-danger"></span>
+            </div>
+        </div>
+
+        <div class="row">
+
+            <div class="col-md-3">
+                <div class="form-group">
+                    <label for="exampleInputEmail1">{{ trans('message.table.discount_type') }}</label>
+                    <select class="form-control select2" name="discount_type" id="discount_type">
+                        <option value="1" {{($saleData->discount_type==1) ? 'selected=selected' : ''}}>Per Item</option>
+                        <option value="2" {{($saleData->discount_type==2) ? 'selected=selected' : ''}}>Per Order</option>
+                    </select>
+                </div>
+            </div>
+
+        </div>
+
+        <br>
+
+        <div class="row">
+            <div class="col-md-6">
+              <div class="form-group">
+                  <label for="exampleInputEmail1">{{ trans('message.form.add_item') }}</label>
+                  <input class="form-control auto" placeholder="{{ trans('message.invoice.search_item') }}" id="search">
+
+                <ul class="ui-autocomplete ui-front ui-menu ui-widget ui-widget-content" id="no_div" tabindex="0" style="display: none; top: 60px; left: 15px; width: 520px;">
+                <li>No record found!</li>
+                </ul>
+
+              </div>
+            </div>
+        </div>
+        <div class="row">
+          <div class="col-md-12">
+            <div class="text-center" id="quantityMessage" style="color:red; font-weight:bold">
+            </div>
+          </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+              <!-- /.box-header -->
+              <div class="box-body no-padding">
+                <div class="table-responsive">
+                <table class="table table-bordered" id="salesInvoice">
+                  <tbody>
+
+                  <tr class="tbl_header_color dynamicRows">
+                    <th width="30%" class="text-center">{{ trans('message.table.description') }}</th>
+                    <th width="10%" class="text-center">{{ trans('message.table.quantity') }}</th>
+                    <th width="10%" class="text-center">{{ trans('message.table.rate') }}({{Session::get('currency_symbol')}})</th>
+                    <th width="15%" class="text-center">{{ trans('message.table.tax') }}(%)</th>
+                    <th width="10%" class="text-center">{{ trans('message.table.tax') }}({{Session::get('currency_symbol')}})</th>
+                    <th width="10%" class="text-center">{{ trans('message.table.discount') }}(%)</th>
+                    <th width="10%" class="text-center">{{ trans('message.table.amount') }}({{Session::get('currency_symbol')}})</th>
+                    <th width="5%"  class="text-center">{{ trans('message.table.action') }}</th>
+                  </tr>
+                  <?php
+                    $taxTotal = 0;
+                    $totalItemQuantity = 0;
+                  ?>
+                  @if(count($invoiceData)>0)
+                    @foreach($invoiceData as $result)
+                        <?php
+                          if(in_array($result->stock_id, $invoicedItem)){
+                            $deleteBtn = 'deleteBtn';
+                          }else{
+                            $deleteBtn = '';
+                          }
+
+                            $priceAmount = ($result->quantity*$result->unit_price);
+                            $discount = ($priceAmount*$result->discount_percent)/100;
+                            $newPrice = ($priceAmount-$discount);
+                            $tax = ($newPrice*$result->tax_rate/100);
+
+                            $totalItemQuantity+=$result->quantity;
+
+                            $taxTotal += $tax;
+                        ?>
+                        <tr id="rowid{{$result->item_id}}">
+                          <td class="text-center">{{$result->description}}<input type="hidden" name="description[]" value="{{$result->description}}"><input type="hidden" name="stock_id[]" value="{{$result->stock_id}}"></td>
+                          <td><input class="form-control text-center no_units" min="0" data-id="{{$result->item_id}}" data-rate="{{$result->unit_price}}" id="qty_{{$result->item_id}}" name="item_quantity[]" value="{{$result->quantity}}" type="text"><input name="item_id[]" value="{{$result->item_id}}" type="hidden"></td>
+                          <td class="text-center"><input min="0" class="form-control text-center unitprice" name="unit_price[]" data-id="{{$result->item_id}}" id="rate_id_{{$result->item_id}}" value="{{$result->unit_price}}" type="text"></td>
+                          <td class="text-center">
+                            <select class="form-control taxList" name="tax_id[]">
+                            @foreach($tax_types as $item)
+                              <option value="{{$item->id}}" taxrate="{{$item->tax_rate}}" <?= ($item->id == $result->tax_type_id ? 'selected':'')?>>{{$item->name}}({{$item->tax_rate}})</option>
+                            @endforeach
+                            </select>
+                          </td>
+                          <td class="text-center taxAmount">{{$tax}}</td>
+                          <td class="text-center"><input class="form-control text-center discount" name="discount[]" data-input-id="{{$result->item_id}}" id="discount_id_{{$result->item_id}}" max="100" min="0" type="text" value="{{$result->discount_percent}}" {{($saleData->discount_type==2) ? 'readonly' : ''}}></td>
+
+                          <td><input amount-id="{{$result->item_id}}" class="form-control text-center amount" id="amount_{{$result->item_id}}" value="{{$newPrice}}" name="item_price[]" readonly type="text"></td>
+                          <td class="text-center"><button id="{{$result->item_id}}" class="btn btn-xs btn-danger delete_item {{$deleteBtn}}"><i class="glyphicon glyphicon-trash"></i></button></td>
+                        </tr>
+                  <?php
+                    $stack[] = $result->item_id;
+                  ?>
+                    @endforeach
+                    <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.discount') }}(%)</strong></td><td align="left" colspan="2"><input type="text" class="form-control" id="perOrderDiscount" name="perOrderDiscount" value="{{$saleData->discount_percent}}" max="100" min="0" {{($saleData->discount_type==1) ? 'readonly' : ''}}></td></tr>
+                  <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.sub_total') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="subTotal"></strong></td></tr>
+                    <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.delivery_price') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="deliveryFee">{{$saleData->delivery_price}}</strong></td></tr>
+                  <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.invoice.totalTax') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><strong id="taxTotal">{{$taxTotal}}</strong></td></tr>
+                  <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.grand_total') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><input type='text' name="total" class="form-control" id = "grandTotal" value="{{ $saleData->total }}" readonly></td></tr>
+                    <tr class="tableInfos"><td colspan="6" align="right"><strong>{{ trans('message.table.downpayment') }}({{Session::get('currency_symbol')}})</strong></td><td align="left" colspan="2"><input type='text' name="downpayment" class="form-control" id="downpayment" value="{{($saleData->debit_amount > 0) ? $saleData->paid_amount : 0}}" min="0"></td></tr>
+                  @endif
+
+                  <!-- To get total items quantity -->
+                  <input type="hidden" name="itemTotalQuantity" id="itemTotalQuantity" value="{{$totalItemQuantity}}">
+
+                  </tbody>
+                </table>
+                </div>
+                <br><br>
+              </div>
+            </div>
+              <!-- /.box-body -->
+              <div class="col-md-12">
+              <div class="form-group">
+                    <label for="exampleInputEmail1">{{ trans('message.table.note') }}</label>
+                    <textarea placeholder="{{ trans('message.table.description') }} ..." rows="3" class="form-control" name="comments"></textarea>
+                </div>
+                <a href="{{url('/order/list')}}" class="btn btn-info btn-flat">{{ trans('message.form.cancel') }}</a>
+                <button id="btnSubmit" type="submit" class="btn btn-primary btn-flat pull-right">{{ trans('message.form.submit') }}</button>
+              </div>
+        </div>
+        </form>
+            <!-- /.col -->
+            
+            <!-- /.col -->
+      </div>
+          <!-- /.row -->
+    </div>
+        <!-- /.box-body -->
+      <!-- /.box -->
+
+    </section>
+@endsection
+@section('js')
+    <script type="text/javascript">
+
+$(function() {
+    $(document).on('click', function(e) {
+        if (e.target.id === 'no_div') {
+            $('#no_div').hide();
+        } else {
+            $('#no_div').hide();
+        }
+
+    })
+});
+
+     var taxOptionList = "{!! $tax_type_new !!}";
+    $(document).ready(function(){
+      var refNo ='SO-'+$("#reference_no").val();
+      $("#reference_no_write").val(refNo);
+      $("#customer").on('change', function(){
+      var debtor_no = $(this).val();
+      $.ajax({
+        method: "POST",
+        url: SITE_URL+"/sales/get-branches",
+        data: { "debtor_no": debtor_no,"_token":token }
+      })
+        .done(function( data ) {
+          var data = jQuery.parseJSON(data);
+          if(data.status_no == 1){
+            $("#branch").html(data.branchs);
+          }
+        });
+      });
+    });
+
+    $(document).on('keyup', '#reference_no', function () {
+        var ref = 'SO-'+$(this).val();
+        $("#reference_no_write").val(ref);
+      // Check Reference no if available
+      $.ajax({
+        method: "POST",
+        url: SITE_URL+"/sales/reference-validation",
+        data: { "ref": ref,"_token":token }
+      })
+        .done(function( data ) {
+          var data = jQuery.parseJSON(data);
+          if(data.status_no == 1){
+            $("#errMsg").html("{{ trans('message.invoice.exist') }}");
+          }else if(data.status_no == 0){
+            $("#errMsg").html("{{ trans('message.invoice.available') }}");
+          }
+        });
+    });
+
+
+    function in_array(search, array)
+    {
+      for (i = 0; i < array.length; i++)
+      {
+        if(array[i] ==search )
+        {
+          return true;
+        }
+      }
+        return false;
+    }
+
+    $(function () {
+        //Initialize Select2 Elements
+        $(".select2").select2({
+
+        });
+
+        //Date picker
+        $('#datepicker').datepicker({
+            autoclose: true,
+            todayHighlight: true,
+            format: '{{Session::get('date_format_type')}}'
+        });
+
+        $('.ref').val(Math.floor((Math.random() * 100) + 1));
+       
+    })
+
+    var stack = [];
+    var stack = <?php echo json_encode($stack); ?>;
+
+    var token = $("#token").val();
+    $( "#search" ).autocomplete({
+        source: function(request, response) {
+            $.ajax({
+                url: "{{URL::to('order/search')}}",
+                dataType: "json",
+                type: "POST",
+                data: {
+                    _token:token,
+                    search: request.term,
+                    salesTypeId:$("#sales_type_id").val()
+                },
+                success: function(data){
+                  //Start
+                    if(data.status_no == 1){
+                    $("#val_item").html();
+                     var data = data.items;
+                     $('#no_div').css('display','none');
+                    response( $.map( data, function( item ) {
+                        return {
+                            id: item.id,
+                            stock_id: item.stock_id,
+                            value: item.description,
+                            units: item.units,
+                            price: item.price,
+                            tax_rate: item.tax_rate,
+                            tax_id: item.tax_id
+                        }
+                    }));
+                  }else{
+                    $('.ui-menu-item').remove();
+                    $("#no_div").css('display','block');
+                  }
+                  //end
+
+                 }
+            })
+        },
+
+        select: function(event, ui) {
+          var e = ui.item;
+          if(e.id) {
+              if(!in_array(e.id, stack))
+              {
+                stack.push(e.id);
+               var taxAmount = (e.price*e.tax_rate)/100;
+                var new_row = '<tr id="rowid'+e.id+'">'+
+                          '<td class="text-center">'+ e.value +'<input type="hidden" name="description_new[]" value="'+e.value+'"><input type="hidden" name="stock_id_new[]" value="'+e.stock_id+'"></td>'+
+                          '<td> <input class="form-control text-center no_units" min="0" data-id="'+e.id+'" data-rate="'+ e.price +'" type="text" id="qty_'+e.id+'" name="item_quantity_new[]" value="1"><input type="hidden" name="item_id_new[]" value="'+e.id+'"></td>'+
+                          '<td class="text-center"><input min="0"  type="text" class="form-control text-center unitprice" name="unit_price_new[]" data-id = "'+e.id+'" id="rate_id_'+e.id+'" value="'+ e.price +'"></td>'+
+                          '<td class="text-center">'+ taxOptionList +'</td>'+
+                          '<td class="text-center taxAmount">'+ taxAmount +'</td>'+
+                          '<td class="text-center"><input type="text" class="form-control text-center discount" name="discount_new[]" data-input-id="'+e.id+'" id="discount_id_'+e.id+'" max="100" min="0" value="0"></td>'+
+                          '<td><input class="form-control text-center amount" type="text" amount-id = "'+e.id+'" id="amount_'+e.id+'" value="'+e.price+'" name="item_price_new[]" readonly></td>'+
+                          '<td class="text-center"><button id="'+e.id+'" class="btn btn-xs btn-danger delete_item"><i class="glyphicon glyphicon-trash"></i></button></td>'+
+                          '</tr>';
+                
+                $(new_row).insertAfter($('table tr.dynamicRows:last'));
+
+                $(function() {
+                    $("#rowid"+e.id+' .taxList').val(e.tax_id);
+                });
+                var taxRateValue = parseFloat( $("#rowid"+e.id+' .taxList').find(':selected').attr('taxrate'));
+
+                // Calculate subtotal
+                var subTotal = calculateSubTotal();
+                var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+                subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+                $("#subTotal").html(subTotal);
+
+                  //Get Delivery Fee
+                  var delivery_fee = parseFloat($("#delivery_price").val());
+                  if(isNaN(delivery_fee)){
+                      delivery_fee = 0;
+                  }
+                  $("#deliveryFee").html(delivery_fee);
+
+                // Calculate Grand Total
+                var taxTotal = calculateTaxTotal();
+                $("#taxTotal").text(taxTotal);
+                var grandTotal = (subTotal + taxTotal + delivery_fee);
+                $("#grandTotal").val(grandTotal);
+
+                  if(parseFloat($("#grandTotal").val()) < 0){
+                      $("#downpayment").val(0);
+                      $("#downpayment").attr('readonly', true);
+                  }else{
+                      $("#downpayment").attr('readonly', false);
+                  }
+
+                $('.tableInfo').show();
+
+
+                  /* Check the total items quantity and previuosly entered quantity
+                   * if previosly entered quantity != currently entered quantity then the user can not submit the new order
+                   **/
+                  var currentTotalQuantity = 0;
+                  var enteredQuantity = parseInt($("#itemTotalQuantity").val());
+
+                  $(".no_units").each(function(){
+                      currentTotalQuantity += parseInt($(this).val());
+                  });
+
+                  getTotalQuantity(currentTotalQuantity, enteredQuantity);
+
+
+              } else {
+                 
+                  $('#qty_'+e.id).val( function(i, oldval) {
+                      return ++oldval;
+                  });
+                  
+                  var q = $('#qty_'+e.id).val();
+                  var r = $("#rate_id_"+e.id).val();
+
+                $('#amount_'+e.id).val( function(i, amount) {
+                    var result = q*r; 
+                    var amountId = $(this).attr("amount-id");
+                    var qty = parseInt($("#qty_"+amountId).val());
+                    var unitPrice = parseFloat($("#rate_id_"+amountId).val());
+                    var discountPercent = parseFloat($("#discount_id_"+amountId).val())/100;
+                    if(isNaN(discountPercent)){
+                      discountPercent = 0;
+                    }
+                    var discountAmount = qty*unitPrice*discountPercent;
+                    var newPrice = parseFloat([(qty*unitPrice)-discountAmount]);
+                    return newPrice;
+                });
+               
+               var taxRateValue = parseFloat( $("#rowid"+e.id+' .taxList').find(':selected').attr('taxrate'));
+               var amountByRow = $('#amount_'+e.id).val(); 
+               var taxByRow = amountByRow*taxRateValue/100;
+              
+               $("#rowid"+e.id+" .taxAmount").text(taxByRow);
+
+                // Calculate subTotal
+                var subTotal = calculateSubTotal();
+                var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+                subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+                $("#subTotal").html(subTotal);
+
+                  //Get Delivery Fee
+                  var delivery_fee = parseFloat($("#delivery_price").val());
+                  if(isNaN(delivery_fee)){
+                      delivery_fee = 0;
+                  }
+                  $("#deliveryFee").html(delivery_fee);
+
+                // Calculate taxTotal
+                var taxTotal = calculateTaxTotal();
+                $("#taxTotal").text(taxTotal);
+                // Calculate GrandTotal
+                var grandTotal = (subTotal + taxTotal + delivery_fee);
+                $("#grandTotal").val(grandTotal);
+
+                  if(parseFloat($("#grandTotal").val()) < 0){
+                      $("#downpayment").val(0);
+                      $("#downpayment").attr('readonly', true);
+                  }else{
+                      $("#downpayment").attr('readonly', false);
+                  }
+
+
+                  /* Check the total items quantity and previuosly entered quantity
+                   * if previosly entered quantity != currently entered quantity then the user can not submit the new order
+                   **/
+                  var currentTotalQuantity = 0;
+                  var enteredQuantity = parseInt($("#itemTotalQuantity").val());
+
+                  $(".no_units").each(function(){
+                      currentTotalQuantity += parseInt($(this).val());
+                  });
+
+                  getTotalQuantity(currentTotalQuantity, enteredQuantity);
+
+              }
+              
+              $(this).val('');
+              $('#val_item').html('');
+
+              //To check what discount type option is selected
+              $("#discount_type").change();
+
+              return false;
+          }
+        },
+        minLength: 1,
+        autoFocus: true
+    });
+
+
+    $(document).on('change keyup blur','.check',function() {
+      var row_id = $(this).attr("id").substr(2);
+      var disc = $(this).val();
+      var amd = $('#a_'+row_id).val();
+
+      if (disc != '' && amd != '') {
+        $('#a_'+row_id).val((parseInt(amd)) - (parseInt(disc)));
+      } else {
+        $('#a_'+row_id).val(parseInt(amd));
+      }
+      
+    });
+
+    $(document).ready(function() {
+          $(window).keydown(function(event){
+            if(event.keyCode == 13) {
+              event.preventDefault();
+              return false;
+            }
+          });
+        });
+
+    // price calcualtion with quantity
+     $(document).ready(function(){
+       $('.tableInfo').hide();
+      });
+
+     // calculate amount with item quantity
+    $(document).on('keyup', '.no_units', function(ev){
+        var id = $(this).attr("data-id");
+        var qty = parseInt($(this).val());
+        var order_no = $("#order_no").val();
+        var reference = $("#reference").val();
+        var token = $("#token").val();
+        var from_stk_loc = $("#loc").val();
+
+        if(isNaN(qty)){
+            qty = 0;
+        }
+
+        /* Check the total items quantity and previuosly entered quantity
+         * if previosly entered quantity != currently entered quantity then the user can not submit the new order
+         **/
+        var currentTotalQuantity = 0;
+        var enteredQuantity = parseInt($("#itemTotalQuantity").val());
+
+        $(".no_units").each(function(){
+            var perQty = $(this).val();
+            if(isNaN(perQty) || perQty==''){
+                perQty=0;
+            }
+            currentTotalQuantity += parseInt(perQty);
+        });
+
+        getTotalQuantity(currentTotalQuantity, enteredQuantity);
+      // check item quantity in store location after sale
+      /*$.ajax({
+        method: "POST",
+        url: SITE_URL+"/order/check-quantity-after-invoice",
+        data: { "id": id,'order_no':order_no,'reference':reference ,"location_id": from_stk_loc,'qty':qty,"_token":token }
+      })
+        .done(function( data ) {
+          var data = jQuery.parseJSON(data);
+         
+          if(data.status_no == 0){
+            $("#quantityMessage").html('You can not decrease the item quantity.');
+            $("#rowid"+id).addClass("insufficient");
+            $('#btnSubmit').attr('disabled', 'disabled');
+          }else if(data.status_no == 1){
+             $("#quantityMessage").html("");
+            $("#rowid"+id).removeClass("insufficient");
+            $("#quantityMessage").hide();
+            $('#btnSubmit').removeAttr('disabled');
+          }
+        });*/
+       
+        var rate = $("#rate_id_"+id).val();
+      
+        var price = calculatePrice(qty,rate);
+
+        var discountRate = parseFloat($("#discount_id_"+id).val());
+        if(isNaN(discountRate)){
+            discountRate = 0;
+        }
+        var discountPrice = calculateDiscountPrice(price,discountRate);
+        $("#amount_"+id).val(discountPrice);
+
+
+        var taxRateValue = parseFloat( $("#rowid"+id+' .taxList').find(':selected').attr('taxrate'));
+        var amountByRow = $('#amount_'+id).val();
+        var taxByRow = amountByRow*taxRateValue/100;
+        $("#rowid"+id+" .taxAmount").text(taxByRow);
+        var taxTotal = calculateTaxTotal();
+        $("#taxTotal").text(taxTotal);
+
+        // Calculate subTotal
+        var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+        $("#subTotal").html(subTotal);
+
+        //Get Delivery Fee
+        var delivery_fee = parseFloat($("#delivery_price").val());
+        if(isNaN(delivery_fee)){
+            delivery_fee = 0;
+        }
+        $("#deliveryFee").html(delivery_fee);
+
+        // Calculate GrandTotal
+        var grandTotal = (subTotal + taxTotal + delivery_fee);
+        $("#grandTotal").val(grandTotal);
+
+        if(parseFloat($("#grandTotal").val()) < 0){
+            $("#downpayment").val(0);
+            $("#downpayment").attr('readonly', true);
+        }else{
+            $("#downpayment").attr('readonly', false);
+        }
+
+    });
+
+
+
+    function getTotalQuantity(currentTotalQuantity, enteredQuantity)
+    {
+        if(currentTotalQuantity < enteredQuantity){
+            $("#quantityMessage").html('Total of all item quantity must be atleast '+enteredQuantity);
+            //$("#rowid"+id).addClass("insufficient");
+            $('#btnSubmit').attr('disabled', 'disabled');
+        }else{
+            $("#quantityMessage").html("");
+            $('#btnSubmit').removeAttr('disabled');
+        }
+
+    }
+
+
+     // calculate amount with discount
+    $(document).on('keyup', '.discount', function(ev){
+     
+      var discount = parseFloat($(this).val());
+
+      if(isNaN(discount)){
+          discount = 0;
+       }
+     
+      var id = $(this).attr("data-input-id");
+      var qty = $("#qty_"+id).val();
+      var rate = $("#rate_id_"+id).val();
+      var discountRate = $("#discount_id_"+id).val();
+
+      var price = calculatePrice(qty,rate); 
+      var discountPrice = calculateDiscountPrice(price,discountRate);       
+      $("#amount_"+id).val(discountPrice);
+
+     var taxRateValue = parseFloat( $("#rowid"+id+' .taxList').find(':selected').attr('taxrate'));
+     var amountByRow = $('#amount_'+id).val(); 
+     var taxByRow = amountByRow*taxRateValue/100;
+     $("#rowid"+id+" .taxAmount").text(taxByRow);
+
+      // Calculate subTotal
+      var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+      $("#subTotal").html(subTotal);
+
+        //Get Delivery Fee
+        var delivery_fee = parseFloat($("#delivery_price").val());
+        if(isNaN(delivery_fee)){
+            delivery_fee = 0;
+        }
+        $("#deliveryFee").html(delivery_fee);
+
+      // Calculate taxTotal
+      var taxTotal = calculateTaxTotal();
+      $("#taxTotal").text(taxTotal);
+      // Calculate GrandTotal
+      var grandTotal = (subTotal + taxTotal + delivery_fee);
+      $("#grandTotal").val(grandTotal);
+
+        if(parseFloat($("#grandTotal").val()) < 0){
+            $("#downpayment").val(0);
+            $("#downpayment").attr('readonly', true);
+        }else{
+            $("#downpayment").attr('readonly', false);
+        }
+
+    });
+
+
+     // calculate amount with unit price
+    $(document).on('keyup', '.unitprice', function(ev){
+     
+      var unitprice = parseFloat($(this).val());
+
+      if(isNaN(unitprice)){
+          unitprice = 0;
+       }
+     
+      var id = $(this).attr("data-id");
+      var qty = $("#qty_"+id).val();
+      var rate = $("#rate_id_"+id).val();
+      var discountRate = $("#discount_id_"+id).val();
+
+      var price = calculatePrice(qty,rate);  
+      var discountPrice = calculateDiscountPrice(price,discountRate);     
+      $("#amount_"+id).val(discountPrice);
+
+     var taxRateValue = parseFloat( $("#rowid"+id+' .taxList').find(':selected').attr('taxrate'));
+     var amountByRow = $('#amount_'+id).val(); 
+     var taxByRow = amountByRow*taxRateValue/100;
+     $("#rowid"+id+" .taxAmount").text(taxByRow);
+
+      // Calculate subTotal
+      var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+      $("#subTotal").html(subTotal);
+        //Fetch delivery fee
+        var deliveryFee = parseFloat($("#delivery_price").val());
+      // Calculate taxTotal
+      var taxTotal = calculateTaxTotal();
+      $("#taxTotal").text(taxTotal);
+      // Calculate GrandTotal
+      var grandTotal = (subTotal + taxTotal + deliveryFee);
+      $("#grandTotal").val(grandTotal);
+
+        if(parseFloat($("#grandTotal").val()) < 0){
+            $("#downpayment").val(0);
+            $("#downpayment").attr('readonly', true);
+        }else{
+            $("#downpayment").attr('readonly', false);
+        }
+
+    });
+
+
+    //Calculate the total on delivery fee changes on delivery text change event
+    $(document).on('keyup', '.delivery_price', function(){
+
+        var deliveryFee = parseFloat($(this).val());
+        if(isNaN(deliveryFee)){
+            deliveryFee = 0;
+        }
+
+        // Fetch subTotal
+        var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+
+        //Set the value in delivery html
+        $("#deliveryFee").html(deliveryFee);
+
+        // Fetch Tax
+        var taxTotal = calculateTaxTotal();
+
+        // Calculate GrandTotal
+        var grandTotal = (subTotal + taxTotal + deliveryFee);
+        $("#grandTotal").val(grandTotal);
+
+        if(parseFloat($("#grandTotal").val()) < 0){
+            $("#downpayment").val(0);
+            $("#downpayment").attr('readonly', true);
+        }else{
+            $("#downpayment").attr('readonly', false);
+        }
+
+    });
+
+    $(document).on('change', '.taxList', function(ev){
+      var taxRateValue = $(this).find(':selected').attr('taxrate');
+      var rowId = $(this).closest('tr').prop('id');
+      var amountByRow = $("#"+rowId+" .amount").val(); 
+      
+      var taxByRow = amountByRow*taxRateValue/100;
+
+      $("#"+rowId+" .taxAmount").text(taxByRow);
+
+      // Calculate subTotal
+      var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+      $("#subTotal").html(subTotal);
+        //Fetch delivery fee
+        var deliveryFee = parseFloat($("#delivery_price").val());
+      // Calculate taxTotal
+      var taxTotal = calculateTaxTotal();
+      $("#taxTotal").text(taxTotal);
+      // Calculate GrandTotal
+      var grandTotal = (subTotal + taxTotal + deliveryFee);
+      $("#grandTotal").val(grandTotal);
+
+        if(parseFloat($("#grandTotal").val()) < 0){
+            $("#downpayment").val(0);
+            $("#downpayment").attr('readonly', true);
+        }else{
+            $("#downpayment").attr('readonly', false);
+        }
+
+    });
+
+    // Delete item row
+    $(document).ready(function(e){
+      $('#salesInvoice').on('click', '.delete_item', function() {
+            var v = $(this).attr("id");
+            stack = jQuery.grep(stack, function(value) {
+              return value != v;
+            });
+            
+            $(this).closest("tr").remove();
+
+            var taxRateValue = parseFloat( $("#rowid"+v+' .taxList').find(':selected').attr('taxrate'));
+           var amountByRow = $('#amount_'+v).val(); 
+           var taxByRow = amountByRow*taxRateValue/100;
+           $("#rowid"+v+" .taxAmount").text(taxByRow);
+            
+            var subTotal = calculateSubTotal();
+            var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+            subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+            $("#subTotal").html(subTotal);
+
+          //Fetch delivery fee
+          var deliveryFee = parseFloat($("#delivery_price").val());
+
+            var taxTotal = calculateTaxTotal();
+            $("#taxTotal").text(taxTotal);
+            // Calculate GrandTotal
+            var grandTotal = (subTotal + taxTotal + deliveryFee);
+            $("#grandTotal").val(grandTotal);
+
+          if(parseFloat($("#grandTotal").val()) < 0){
+              $("#downpayment").val(0);
+              $("#downpayment").attr('readonly', true);
+          }else{
+              $("#downpayment").attr('readonly', false);
+          }
+
+        });
+
+    });
+
+
+    //Discount type drop down on change
+    $(document).on('change', '#discount_type', function(){
+        if($(this).val()=='2') {
+            $('.discount').val(0);
+            //reclaculate the total calculation after exclude per item discount after setting per item discount 0
+            $('.discount').keyup();
+            $('.discount').attr('readonly', true);
+            $('#perOrderDiscount').attr('readonly', false);
+        }else{
+            $('.discount').attr('readonly', false);
+            $('#perOrderDiscount').val(0);
+            //reclaculate the total calculation after exclude per item discount after setting per item discount 0
+            $('.discount').keyup();
+            $('#perOrderDiscount').attr('readonly', true);
+        }
+    });
+
+
+    //per order discount key up event
+    $(document).on('keyup', '#perOrderDiscount', function(){
+
+        // Calculate subTotal
+        var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($(this).val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+        $("#subTotal").html(subTotal);
+        //Fetch delivery fee
+        var deliveryFee = parseFloat($("#delivery_price").val());
+        // Calculate taxTotal
+        var taxTotal = calculateTaxTotal();
+        $("#taxTotal").text(taxTotal);
+        // Calculate GrandTotal
+        var grandTotal = (subTotal + taxTotal + deliveryFee);
+        $("#grandTotal").val(grandTotal);
+
+        if(parseFloat($("#grandTotal").val()) < 0){
+            $("#downpayment").val(0);
+            $("#downpayment").attr('readonly', true);
+        }else{
+            $("#downpayment").attr('readonly', false);
+        }
+
+    });
+      
+      /**
+      * Calcualte Total tax
+      *@return totalTax for row wise
+      */
+      function calculateTaxTotal (){
+          var totalTax = 0;
+            $('.taxAmount').each(function() {
+                totalTax += parseFloat($(this).text());
+            });
+            return totalTax;
+      }
+      
+      /**
+      * Calcualte Sub Total 
+      *@return subTotal
+      */
+      function calculateSubTotal (){
+        var subTotal = 0;
+        $('.amount').each(function() {
+            subTotal += parseFloat($(this).val());
+        });
+        return subTotal;
+      }
+      /**
+      * Calcualte price
+      *@return price
+      */
+      function calculatePrice (qty,rate){
+         var price = (qty*rate);
+         return price;
+      }   
+      // calculate tax 
+      function caculateTax(p,t){
+       var tax = (p*t)/100;
+       return tax;
+      }   
+
+
+      // calculate discont amount
+      function calculateDiscountPrice(p,d){
+        var discount = [(d*p)/100];
+        var result = (p-discount); 
+        return result;
+      }
+
+
+    //Calculate disccount for per order
+    function calculatePerOrderDiscount(total, discount){
+        var finalDiscount = (discount * total)/100;
+        var totalAfterDiscount = total - finalDiscount;
+
+        return totalAfterDiscount;
+    }
+
+    //Calculation after excluding order discount
+    function excludeOrderDiscount(total, discount){
+        var finalDiscount = (discount * total)/100;
+        var totalAfterDiscount = total + finalDiscount;
+
+        return totalAfterDiscount;
+    }
+
+// Item form validation
+
+    jQuery.validator.addMethod("comparison", function (value, element) {
+        if(pcompra > 0) {
+            return this.optional(element) || parseFloat(value) <= pcompra;
+        }else{
+            return this.optional(element) || parseFloat(value) == 0;
+        }
+    });
+
+    $('#salesForm').validate({
+        rules: {
+            debtor_no: {
+                required: true
+            },
+            from_stk_loc: {
+                required: true
+            },
+            ord_date:{
+               required: true
+            },
+            reference:{
+              required:true
+            },
+            payment_id:{
+              required:true
+            },
+            branch_id:{
+              required:true
+            },
+            delivery_price: {
+                number:true
+            },
+            downpayment: {
+                number:true,
+                comparison: true,
+                min: 0,
+                required: true
+            }
+        },
+        messages: {
+            downpayment:{
+                comparison: "Please insert value less than or equal to grand total",
+                required: "Please enter the down payment amount"
+            }
+
+        }
+    });
+
+    $(document).ready(function(){
+        var subTotal = calculateSubTotal();
+        var perOrderDiscount = parseFloat($('#perOrderDiscount').val());
+        subTotal = calculatePerOrderDiscount(subTotal, perOrderDiscount);
+        $("#subTotal").text(subTotal);
+
+        var grandTotal = parseFloat($('#grandTotal').val());
+
+        if(parseFloat($("#grandTotal").val()) < 0){
+            $("#downpayment").val(0);
+            $("#downpayment").attr('readonly', true);
+        }else{
+            $("#downpayment").attr('readonly', false);
+        }
+
+
+      });
+
+    </script>
+@endsection

--- a/resources/views/admin/salesOrder/orderReturn.blade.php
+++ b/resources/views/admin/salesOrder/orderReturn.blade.php
@@ -7,7 +7,7 @@
       <div class="col-md-12">
         <div class="box box-default">
            <div class="box-header">
-              <h4 class="text-info ">{{ trans('message.table.order_no')}} # <a href="{{url('order/view-order-details/'.$saleData->order_no)}}">{{$saleData->reference}}</a></h4>
+              <h4 class="text-info ">Return and Exchange {{ trans('message.table.order_no')}} # <a href="{{url('order/view-order-details/'.$saleData->order_no)}}">{{$saleData->reference}}</a></h4>
             </div>
         <!-- /.box-header -->
         <div class="box-body">
@@ -883,6 +883,18 @@ $(function() {
           }else{
               $("#downpayment").attr('readonly', false);
           }
+
+          /* Check the total items quantity and previuosly entered quantity
+           * if previosly entered quantity != currently entered quantity then the user can not submit the new order
+           **/
+          var currentTotalQuantity = 0;
+          var enteredQuantity = parseInt($("#itemTotalQuantity").val());
+
+          $(".no_units").each(function(){
+              currentTotalQuantity += parseInt($(this).val());
+          });
+
+          getTotalQuantity(currentTotalQuantity, enteredQuantity);
 
         });
 

--- a/resources/views/admin/salesOrder/viewOrderDetails.blade.php
+++ b/resources/views/admin/salesOrder/viewOrderDetails.blade.php
@@ -32,7 +32,19 @@
                     </div>
                     <div class="col-md-8">
                       <div class="btn-group pull-right">
-                        <button title="Email" type="button" class="btn btn-default btn-flat" data-toggle="modal" data-target="#emailOrder">{{ trans('message.extra_text.email') }}</button>
+
+                          <?php
+                            if(empty($invoiceList) && empty($paymentsList) && empty($shipmentList)){
+                                $orderReturnUrl = URL::to('/').'/order/return/'.$saleData->order_no;
+                                $disableClass = "";
+                            }else{
+                                $orderReturnUrl = "javascript:void(0);";
+                                $disableClass = "disabled";
+                            }
+                          ?>
+
+                          <a href="{{$orderReturnUrl}}" title="Order Return" class="btn btn-default btn-flat {{$disableClass}}">{{ trans('message.extra_text.order_return') }}</a>
+                          <button title="Email" type="button" class="btn btn-default btn-flat" data-toggle="modal" data-target="#emailOrder">{{ trans('message.extra_text.email') }}</button>
                         <a target="_blank" href="{{URL::to('/')}}/order/print/{{$saleData->order_no}}" title="Print" class="btn btn-default btn-flat">{{ trans('message.extra_text.print') }}</a>
                         <a target="_blank" href="{{URL::to('/')}}/order/pdf/{{$saleData->order_no}}" title="PDF" class="btn btn-default btn-flat">{{ trans('message.extra_text.pdf') }}</a>
                         @if(!empty(Session::get('order_edit')))


### PR DESCRIPTION
Enable Returns of Sales Orders:
-He can choose same or more amount. So if he purchased 500 pesos, he can exchange 500 or more pesos. If he exchanged 600 pesos, he will need to pay 100 pesos. If he returned 1 vanilla mix, inventory must be updated to add 1 vanilla mix. If he exchanges for 2 chocolate mixes, inventory must be updated to reduce 2 chocolate mixes.
-In the Sales Order page, for example Sales Order 001, under "Due", Option to "Add Item" from the Items just like when adding a new Sales Order then automatically total and add Notes and click "Submit" then compute how much is payable, if any